### PR TITLE
[Fix] Fix github worflow build job won't fail when pytest fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,20 @@
 
 name: build
 
-on: push
+on:
+  push:
+    branches:
+     - main
+    paths-ignore:
+      - 'README.md'
+      - 'README_CN.md'
+      - 'docs/**'
+
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'README_CN.md'
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,20 +3,7 @@
 
 name: build
 
-on:
-  push:
-    branches:
-     - main
-    paths-ignore:
-      - 'README.md'
-      - 'README_CN.md'
-      - 'docs/**'
-
-  pull_request:
-    paths-ignore:
-      - 'README.md'
-      - 'README_CN.md'
-      - 'docs/**'
+on: push
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -30,6 +17,8 @@ jobs:
         shell: bash -l {0}
     container:
       image: openxrlab/xrmocap_runtime:ubuntu1804_x64_cu102_py38_torch181_mmcv153
+      env:
+        GITHUB_ACTIONS: true
     steps:
       - uses: actions/checkout@v2
       - name: Show conda env
@@ -59,10 +48,17 @@ jobs:
           source /root/miniconda3/etc/profile.d/conda.sh && conda activate openxrlab
           pip install xrprimer
           pip install -e .
-      - name: Run unittests and generate coverage report
+      - name: Install pytest plugin
+        run: |
+          source /root/miniconda3/etc/profile.d/conda.sh && conda activate openxrlab
+          pip install pytest-github-actions-annotate-failures
+      - name: Run unittests
         run: |
           source /root/miniconda3/etc/profile.d/conda.sh && conda activate openxrlab
           coverage run --source xrmocap -m pytest tests/
+      - name: Generate coverage report
+        run: |
+          source /root/miniconda3/etc/profile.d/conda.sh && conda activate openxrlab
           coverage xml
           coverage report -m
       - name: Upload coverage to Codecov


### PR DESCRIPTION
* add a pytest plugin to locate error

* do some experiments to find out when a job fails

* split test and coverage report into two steps