### PR TITLE
[Fix] Fix bug in smplx.py and align default parameter to offical SMPLX

### DIFF
--- a/xrmocap/model/body_model/smplx.py
+++ b/xrmocap/model/body_model/smplx.py
@@ -102,7 +102,8 @@ class SMPLX(_SMPLX):
         """
 
         kwargs['get_skin'] = True
-        smplx_output = super(SMPLX, self).forward(*args, **kwargs)
+        smplx_output = super(SMPLX, self).forward(*args, return_verts=return_verts, 
+                                                  return_full_pose=return_full_pose, **kwargs)
 
         if not hasattr(self, 'joints_regressor'):
             joints = smplx_output.joints

--- a/xrmocap/model/body_model/smplx.py
+++ b/xrmocap/model/body_model/smplx.py
@@ -22,7 +22,7 @@ class SMPLX(_SMPLX):
                  *args,
                  use_face_contour: bool = True,
                  use_pca: bool = False,
-                 flat_hand_mean: bool = True,
+                 flat_hand_mean: bool = False,
                  keypoint_convention: str = 'smplx',
                  joints_regressor: str = None,
                  extra_joints_regressor: str = None,


### PR DESCRIPTION
1. Bug fix: smplx_output not passing bool parameters: 
`return_verts=return_verts, return_full_pose=return_full_pose`
2. Align arguments `flat_hand_mean: bool = True` to the offical smplx