### PR TITLE
[Feature] Add smpl visualization and mask in smpl data

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: seed-isort-config
         args: [--settings-path, ./]
   - repo: https://github.com/PyCQA/isort.git
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--settings-file, ./setup.cfg]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,12 @@ RUN . /root/miniconda3/etc/profile.d/conda.sh && \
     cd mmhuman3d && pip install -e . && \
     pip cache purge
 
+# Install mpr for mesh visualization
+RUN . /root/miniconda3/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip install git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git && \
+    pip cache purge
+
 # Clone xrmocap and install
 RUN . /root/miniconda3/etc/profile.d/conda.sh && \
     conda activate openxrlab && \

--- a/docs/en/data_structure/smpl_data.md
+++ b/docs/en/data_structure/smpl_data.md
@@ -50,7 +50,7 @@ c. New an instance with a dict.
 
 ```python
 smpl_dict = dict(smpl_data)
-another_smpl_data = SMPLData(src_dict=smpl_dict)
+another_smpl_data = SMPLData.from_dict(smpl_dict)
 ```
 
 ### Convert into body_model input

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -155,22 +155,21 @@ If everything goes well, try to [run unittest](#test-environment) or go back to 
 We provide a [Dockerfile](../../Dockerfile) to build an image. Ensure that you are using [docker version](https://docs.docker.com/engine/install/) >=19.03 and `"default-runtime": "nvidia"` in `daemon.json`.
 
 ```shell
-# build an image with PyTorch 1.8.1, CUDA 10.2
-docker build -t xrmocap .
-```
-
-Run it with
-
-```shell
-docker run --gpus all --shm-size=8g -it -v {DATA_DIR}:/xrmocap/data xrmocap
+sh scripts/build_docker.sh
 ```
 
 Or pull a built image from docker hub.
 
 ```shell
-docker pull openxrlab/xrmocap_runtime
-docker run --gpus all --shm-size=8g -it -v {DATA_DIR}:/xrmocap/data openxrlab/xrmocap_runtime
+docker pull openxrlab/xrmocap_runtime:ubuntu1804_x64_cu114_py38_torch1120_mmcv161
 ```
+
+Run it with:
+
+```shell
+sh scripts/run_docker.sh
+```
+
 
 ### Test environment
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -28,7 +28,7 @@ Optional:
 | [MMTracking](https://github.com/open-mmlab/mmtracking)   | Multiple object tracking.      | Install `mmcv-full`, instead of `mmcv`.                      |
 | [MMDeploy](https://github.com/open-mmlab/mmdeploy)       | Faster mmdet+mmpose inference. | Install `mmcv-full`, `cudnn` and `TensorRT`.                 |
 | [Aniposelib](https://github.com/google/aistplusplus_api) | Triangulation.                 | Install from [github](https://github.com/liruilong940607/aniposelib), instead of pypi. |
-| [Minimal Pytorch Rasterizer](https://github.com/rmbashirov/minimal_pytorch_rasterizer) | SMPL mesh fast visualization.                 | Sensitive to pytorch version. |
+| [Minimal Pytorch Rasterizer](https://github.com/rmbashirov/minimal_pytorch_rasterizer) | SMPL mesh fast visualization.                 | Tested on torch-1.12.0. |
 
 ## A from-scratch setup script
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -28,6 +28,7 @@ Optional:
 | [MMTracking](https://github.com/open-mmlab/mmtracking)   | Multiple object tracking.      | Install `mmcv-full`, instead of `mmcv`.                      |
 | [MMDeploy](https://github.com/open-mmlab/mmdeploy)       | Faster mmdet+mmpose inference. | Install `mmcv-full`, `cudnn` and `TensorRT`.                 |
 | [Aniposelib](https://github.com/google/aistplusplus_api) | Triangulation.                 | Install from [github](https://github.com/liruilong940607/aniposelib), instead of pypi. |
+| [Minimal Pytorch Rasterizer](https://github.com/rmbashirov/minimal_pytorch_rasterizer) | SMPL mesh fast visualization.                 | Sensitive to pytorch version. |
 
 ## A from-scratch setup script
 

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,6 +2,7 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 filterpy
 h5py
 mediapipe
+minimal_pytorch_rasterizer @ git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git
 mmdet @ git+https://github.com/open-mmlab/mmdetection.git
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
 mmpose @ git+https://github.com/open-mmlab/mmpose.git

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,6 +2,7 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 coverage
 filterpy
 mediapipe
+minimal_pytorch_rasterizer @ git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git
 mmdet @ git+https://github.com/open-mmlab/mmdetection.git
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
 mmpose @ git+https://github.com/open-mmlab/mmpose.git

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,14 @@
+# build according to Dockerfile
+FINAL_TAG=openxrlab/xrmocap_runtime:ubuntu1804_x64_cu114_py38_torch1120_mmcv161
+TAG=${FINAL_TAG}_not_compatible
+eval $(ssh-agent)
+ssh-add ~/.ssh/id_rsa
+docker build --ssh default=${SSH_AUTH_SOCK} -t $TAG -f Dockerfile .
+# remove 2 files to be compatible with newer docker
+CONTAINER_ID=$(docker run -ti -d $TAG)
+docker exec -ti $CONTAINER_ID sh -c "
+    rm /usr/lib/x86_64-linux-gnu/libnvidia-ml.so.1
+    rm /usr/lib/x86_64-linux-gnu/libcuda.so.1"
+docker commit $CONTAINER_ID $FINAL_TAG
+docker rm -f $CONTAINER_ID
+echo "Successfully tagged $FINAL_TAG"

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+TAG="openxrlab/xrmocap_runtime:ubuntu1804_x64_cu114_py38_torch1120_mmcv161"
+# modify data mount below
+VOLUMES="-v $PWD:/workspace/xrmocap -v /data:/workspace/xrmocap/data"
+WORKDIR="-w /workspace/xrmocap"
+docker run --runtime=nvidia -it --shm-size=24g $VOLUMES $WORKDIR $TAG $@

--- a/tests/core/visualization/test_visualize_smpl.py
+++ b/tests/core/visualization/test_visualize_smpl.py
@@ -1,0 +1,213 @@
+# yapf: disable
+import numpy as np
+import os
+import pytest
+import shutil
+from xrprimer.data_structure.camera import (
+    FisheyeCameraParameter, PinholeCameraParameter,
+)
+
+from xrmocap.core.visualization.visualize_smpl import visualize_smpl_data
+from xrmocap.data_structure.body_model import SMPLData
+from xrmocap.model.body_model.builder import build_body_model
+
+# yapf: enable
+
+input_dir = 'tests/data/core/visualization'
+output_dir = 'tests/data/output/core/visualization'
+
+
+@pytest.fixture(scope='module', autouse=True)
+def fixture():
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+    os.makedirs(output_dir, exist_ok=False)
+
+
+def test_visualize_smpl_data():
+    # load data
+    smpl_data_list = []
+    smpl_data_dir = os.path.join(input_dir, 'Shelf_unittest', 'smpl_data')
+    for person_idx in range(5):
+        file_name = f'smpl_{person_idx}.npz'
+        file_path = os.path.join(smpl_data_dir, file_name)
+        smpl_data = SMPLData.fromfile(file_path)
+        smpl_data_list.append(smpl_data)
+    img_dir = os.path.join(input_dir, 'Shelf_unittest', 'Camera0')
+    fisheye_path = os.path.join(input_dir, 'Shelf_unittest',
+                                'xrmocap_meta_perception2d', 'scene_0',
+                                'camera_parameters', 'fisheye_param_00.json')
+    fisheye_param = FisheyeCameraParameter.fromfile(fisheye_path)
+    pinhole_param = PinholeCameraParameter(
+        K=fisheye_param.get_intrinsic(),
+        R=fisheye_param.get_extrinsic_r(),
+        T=fisheye_param.get_extrinsic_t(),
+        name=fisheye_param.name,
+        height=fisheye_param.height,
+        width=fisheye_param.width,
+        world2cam=fisheye_param.world2cam,
+        convention=fisheye_param.convention)
+    # test one person, one gender
+    neutral_cfg = dict(
+        type='SMPL',
+        gender='neutral',
+        num_betas=10,
+        keypoint_convention='smpl_45',
+        model_path='xrmocap_data/body_models/smpl',
+        batch_size=1)
+    neutral_model = build_body_model(neutral_cfg)
+    output_frames = os.path.join(output_dir, 'sperson_sgender')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list[0],
+        body_model=neutral_model,
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test one person, one gender, body_model in cfg
+    output_frames = os.path.join(output_dir, 'sperson_sgender_cfg.mp4')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list[0],
+        body_model=neutral_cfg,
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test one person, one gender, list of models
+    output_frames = os.path.join(output_dir, 'sperson_sgender_model_list.mp4')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list[0],
+        body_model=[
+            neutral_model,
+        ],
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test one person, one gender, list of models
+    output_frames = os.path.join(output_dir, 'sperson_sgender_cfg_list.mp4')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list[0],
+        body_model=[
+            neutral_cfg,
+        ],
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test multi-person, one gender
+    output_frames = os.path.join(output_dir, 'mperson_sgender')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list,
+        body_model=neutral_model,
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test multi-person, one gender, with mask
+    mask = smpl_data_list[0].get_mask()
+    mask[:2] = 0
+    smpl_data_list[0].set_mask(mask)
+    mask = smpl_data_list[1].get_mask()
+    mask[2:4] = 0
+    smpl_data_list[1].set_mask(mask)
+    output_frames = os.path.join(output_dir, 'mperson_sgender_mask')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list,
+        body_model=neutral_model,
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test background_arr
+    black_background = np.zeros(shape=(5, 776, 1032, 3), dtype=np.uint8)
+    smpl_data_list[0].set_mask(np.ones_like(mask))
+    smpl_data_list[1].set_mask(np.ones_like(mask))
+    output_video = os.path.join(output_dir, 'background_arr.mp4')
+    visualize_smpl_data(
+        smpl_data=smpl_data_list,
+        body_model=neutral_model,
+        cam_param=pinhole_param,
+        output_path=output_video,
+        overwrite=True,
+        background_arr=black_background,
+    )
+    # skip background_video until xrprimer release
+    # the fix of video_to_array()
+
+    # # test background_video
+    # bg_video_path = os.path.join(output_dir, 'black_background.mp4')
+    # array_to_video(image_array=black_background, output_path=bg_video_path)
+    # output_video = os.path.join(output_dir, 'background_video.mp4')
+    # visualize_smpl_data(
+    #     smpl_data=smpl_data_list,
+    #     body_model=neutral_model,
+    #     cam_param=pinhole_param,
+    #     output_path=output_video,
+    #     overwrite=True,
+    #     background_video=bg_video_path,
+    # )
+
+
+@pytest.mark.skipif(
+    not os.path.exists('xrmocap_data/body_models/smpl/SMPL_FEMALE.pkl'),
+    reason='SMPL_FEMALE.pkl has not been found.')
+def test_visualize_smpl_data_mgender():
+    # load data
+    smpl_data_list = []
+    smpl_data_dir = os.path.join(input_dir, 'Shelf_unittest', 'smpl_data')
+    for person_idx in range(5):
+        file_name = f'smpl_{person_idx}.npz'
+        file_path = os.path.join(smpl_data_dir, file_name)
+        smpl_data = SMPLData.fromfile(file_path)
+        smpl_data_list.append(smpl_data)
+    img_dir = os.path.join(input_dir, 'Shelf_unittest', 'Camera0')
+    fisheye_path = os.path.join(input_dir, 'Shelf_unittest',
+                                'xrmocap_meta_perception2d', 'scene_0',
+                                'camera_parameters', 'fisheye_param_00.json')
+    fisheye_param = FisheyeCameraParameter.fromfile(fisheye_path)
+    pinhole_param = PinholeCameraParameter(
+        K=fisheye_param.get_intrinsic(),
+        R=fisheye_param.get_extrinsic_r(),
+        T=fisheye_param.get_extrinsic_t(),
+        name=fisheye_param.name,
+        height=fisheye_param.height,
+        width=fisheye_param.width,
+        world2cam=fisheye_param.world2cam,
+        convention=fisheye_param.convention)
+    # test two person, two gender
+    neutral_cfg = dict(
+        type='SMPL',
+        gender='neutral',
+        num_betas=10,
+        keypoint_convention='smpl_45',
+        model_path='xrmocap_data/body_models/smpl',
+        batch_size=1)
+    female_cfg = neutral_cfg.copy()
+    female_cfg['gender'] = 'female'
+    output_frames = os.path.join(output_dir, 'sperson_mgender')
+    smpl_data_list[1]['gender'] = 'female'
+    visualize_smpl_data(
+        smpl_data=smpl_data_list[0:2],
+        body_model=[neutral_cfg, female_cfg],
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+    )
+    # test one person, two gender, but not enough body model
+    with pytest.raises(KeyError):
+        visualize_smpl_data(
+            smpl_data=smpl_data_list[0:2],
+            body_model=[neutral_cfg],
+            cam_param=pinhole_param,
+            output_path=output_frames,
+            overwrite=True,
+            background_dir=img_dir,
+        )

--- a/tests/core/visualization/test_visualize_smpl.py
+++ b/tests/core/visualization/test_visualize_smpl.py
@@ -3,6 +3,7 @@ import numpy as np
 import os
 import pytest
 import shutil
+import torch
 from xrprimer.data_structure.camera import (
     FisheyeCameraParameter, PinholeCameraParameter,
 )
@@ -24,6 +25,8 @@ def fixture():
     os.makedirs(output_dir, exist_ok=False)
 
 
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason='No GPU device has been found.')
 def test_visualize_smpl_data():
     # load data
     smpl_data_list = []
@@ -63,8 +66,7 @@ def test_visualize_smpl_data():
         cam_param=pinhole_param,
         output_path=output_frames,
         overwrite=True,
-        background_dir=img_dir,
-    )
+        background_dir=img_dir)
     # test one person, one gender, body_model in cfg
     output_frames = os.path.join(output_dir, 'sperson_sgender_cfg.mp4')
     visualize_smpl_data(

--- a/tests/core/visualization/test_visualize_smpl.py
+++ b/tests/core/visualization/test_visualize_smpl.py
@@ -99,6 +99,38 @@ def test_visualize_smpl_data():
         overwrite=True,
         background_dir=img_dir,
     )
+    # test return array
+    ret_arr = visualize_smpl_data(
+        smpl_data=smpl_data_list[0],
+        body_model=neutral_cfg,
+        cam_param=pinhole_param,
+        output_path=output_frames,
+        overwrite=True,
+        background_dir=img_dir,
+        return_array=True)
+    assert len(ret_arr.shape) == 4 and ret_arr.shape[0] == 5
+    # test not overwriting
+    with pytest.raises(FileExistsError):
+        visualize_smpl_data(
+            smpl_data=smpl_data_list[0],
+            body_model=neutral_cfg,
+            cam_param=pinhole_param,
+            output_path=output_frames,
+            overwrite=False,
+            background_dir=img_dir)
+    # skip batch_size=1 until xrprimer release
+    # the fix of images_to_video()
+
+    # # test one frame per batch
+    # visualize_smpl_data(
+    #     smpl_data=smpl_data_list[0],
+    #     body_model=neutral_cfg,
+    #     cam_param=pinhole_param,
+    #     output_path=output_frames,
+    #     overwrite=True,
+    #     background_dir=img_dir,
+    #     batch_size=1
+    # )
     # test multi-person, one gender
     output_frames = os.path.join(output_dir, 'mperson_sgender')
     visualize_smpl_data(
@@ -139,7 +171,7 @@ def test_visualize_smpl_data():
         background_arr=black_background,
     )
     # skip background_video until xrprimer release
-    # the fix of video_to_array()
+    # the fix of array_to_video()
 
     # # test background_video
     # bg_video_path = os.path.join(output_dir, 'black_background.mp4')

--- a/tests/core/visualization/test_visualize_smpl.py
+++ b/tests/core/visualization/test_visualize_smpl.py
@@ -4,9 +4,11 @@ import os
 import pytest
 import shutil
 import torch
+from xrprimer import __version__ as xrprimer_version
 from xrprimer.data_structure.camera import (
     FisheyeCameraParameter, PinholeCameraParameter,
 )
+from xrprimer.utils.ffmpeg_utils import array_to_video
 
 from xrmocap.core.visualization.visualize_smpl import visualize_smpl_data
 from xrmocap.data_structure.body_model import SMPLData
@@ -123,16 +125,16 @@ def test_visualize_smpl_data():
     # skip batch_size=1 until xrprimer release
     # the fix of images_to_video()
 
-    # # test one frame per batch
-    # visualize_smpl_data(
-    #     smpl_data=smpl_data_list[0],
-    #     body_model=neutral_cfg,
-    #     cam_param=pinhole_param,
-    #     output_path=output_frames,
-    #     overwrite=True,
-    #     background_dir=img_dir,
-    #     batch_size=1
-    # )
+    # test one frame per batch
+    if int(xrprimer_version.split('.')[1]) > 6:
+        visualize_smpl_data(
+            smpl_data=smpl_data_list[0],
+            body_model=neutral_cfg,
+            cam_param=pinhole_param,
+            output_path=output_frames,
+            overwrite=True,
+            background_dir=img_dir,
+            batch_size=1)
     # test multi-person, one gender
     output_frames = os.path.join(output_dir, 'mperson_sgender')
     visualize_smpl_data(
@@ -175,18 +177,19 @@ def test_visualize_smpl_data():
     # skip background_video until xrprimer release
     # the fix of array_to_video()
 
-    # # test background_video
-    # bg_video_path = os.path.join(output_dir, 'black_background.mp4')
-    # array_to_video(image_array=black_background, output_path=bg_video_path)
-    # output_video = os.path.join(output_dir, 'background_video.mp4')
-    # visualize_smpl_data(
-    #     smpl_data=smpl_data_list,
-    #     body_model=neutral_model,
-    #     cam_param=pinhole_param,
-    #     output_path=output_video,
-    #     overwrite=True,
-    #     background_video=bg_video_path,
-    # )
+    # test background_video
+    if int(xrprimer_version.split('.')[1]) > 6:
+        bg_video_path = os.path.join(output_dir, 'black_background.mp4')
+        array_to_video(image_array=black_background, output_path=bg_video_path)
+        output_video = os.path.join(output_dir, 'background_video.mp4')
+        visualize_smpl_data(
+            smpl_data=smpl_data_list,
+            body_model=neutral_model,
+            cam_param=pinhole_param,
+            output_path=output_video,
+            overwrite=True,
+            background_video=bg_video_path,
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/data_structure/body_model/test_smpl_data.py
+++ b/tests/data_structure/body_model/test_smpl_data.py
@@ -22,9 +22,6 @@ def test_new():
     smpl_data = SMPLData()
     assert hasattr(smpl_data, 'logger')
     assert smpl_data.logger is not None
-    # new from dict
-    smpl_data = SMPLData({'n_frame': 20})
-    assert smpl_data['n_frame'] == 20
     # new with specific value
     smpl_data = SMPLData(
         gender='neutral',
@@ -33,16 +30,11 @@ def test_new():
         betas=np.zeros(shape=(2, 10)),
         logger='root')
     assert smpl_data['betas'][0, 0] == 0
-    # new with source dict
-    src_dict = {'n_frame': 2, 'betas': np.ones(shape=(2, 10))}
-    smpl_data = SMPLData(
-        src_dict=src_dict,
-        gender='neutral',
-        fullpose=np.zeros(shape=(2, 24, 3)),
-        transl=np.zeros(shape=(2, 3)),
-        betas=np.zeros(shape=(2, 10)),
-        logger='root')
-    assert smpl_data['betas'][0, 0] == 0
+    # new with smpl_dict
+    smpl_data['betas'][0, 0] = 1
+    smpl_data_dict = dict(smpl_data)
+    smpl_data = SMPLData.from_dict(smpl_data_dict)
+    assert smpl_data['betas'][0, 0] == 1
 
 
 def test_set_gender():

--- a/tests/data_structure/body_model/test_smpl_data.py
+++ b/tests/data_structure/body_model/test_smpl_data.py
@@ -28,6 +28,7 @@ def test_new():
         fullpose=np.zeros(shape=(2, 24, 3)),
         transl=np.zeros(shape=(2, 3)),
         betas=np.zeros(shape=(2, 10)),
+        mask=np.ones(shape=(2, )),
         logger='root')
     assert smpl_data['betas'][0, 0] == 0
     # new with smpl_dict

--- a/tests/data_structure/body_model/test_smplx_data.py
+++ b/tests/data_structure/body_model/test_smplx_data.py
@@ -29,6 +29,7 @@ def test_new():
         fullpose=np.zeros(shape=(2, 55, 3)),
         transl=np.zeros(shape=(2, 3)),
         betas=np.zeros(shape=(2, 10)),
+        mask=np.ones(shape=(2, )),
         logger='root')
     assert smplx_data['betas'][0, 0] == 0
     assert smplx_data.get_expression().shape == (2, 10)

--- a/tests/data_structure/body_model/test_smplx_data.py
+++ b/tests/data_structure/body_model/test_smplx_data.py
@@ -23,9 +23,6 @@ def test_new():
     assert hasattr(smplx_data, 'logger')
     assert smplx_data.logger is not None
     assert smplx_data.get_fullpose().shape[1] == 55
-    # new from dict
-    smplx_data = SMPLXData({'frame_num': 20})
-    assert smplx_data['frame_num'] == 20
     # new with specific value
     smplx_data = SMPLXData(
         gender='neutral',
@@ -35,16 +32,11 @@ def test_new():
         logger='root')
     assert smplx_data['betas'][0, 0] == 0
     assert smplx_data.get_expression().shape == (2, 10)
-    # new with source dict
-    src_dict = {'frame_num': 2, 'betas': np.ones(shape=(2, 10))}
-    smplx_data = SMPLXData(
-        src_dict=src_dict,
-        gender='neutral',
-        fullpose=np.zeros(shape=(2, 55, 3)),
-        transl=np.zeros(shape=(2, 3)),
-        betas=np.zeros(shape=(2, 10)),
-        logger='root')
-    assert smplx_data['betas'][0, 0] == 0
+    # new with smplx_data_dict
+    smplx_data['betas'][0, 0] = 1
+    smplx_data_dict = dict(smplx_data)
+    smplx_data = SMPLXData.from_dict(smplx_data_dict)
+    assert smplx_data['betas'][0, 0] == 1
 
 
 def test_set_gender():

--- a/tests/data_structure/body_model/test_smplxd_data.py
+++ b/tests/data_structure/body_model/test_smplxd_data.py
@@ -23,9 +23,6 @@ def test_new():
     assert hasattr(smplxd_data, 'logger')
     assert smplxd_data.logger is not None
     assert smplxd_data.get_fullpose().shape[1] == 55
-    # new from dict
-    smplxd_data = SMPLXDData({'frame_num': 20})
-    assert smplxd_data['frame_num'] == 20
     # new with specific value
     smplxd_data = SMPLXDData(
         gender='neutral',
@@ -36,17 +33,11 @@ def test_new():
         logger='root')
     assert smplxd_data['betas'][0, 0] == 0
     assert smplxd_data.get_expression().shape == (2, 10)
-    # new with source dict
-    src_dict = {'frame_num': 2, 'betas': np.ones(shape=(2, 10))}
-    smplxd_data = SMPLXDData(
-        src_dict=src_dict,
-        gender='neutral',
-        fullpose=np.zeros(shape=(2, 55, 3)),
-        transl=np.zeros(shape=(2, 3)),
-        betas=np.zeros(shape=(2, 10)),
-        displacement=np.zeros(shape=(2, 10475)),
-        logger='root')
-    assert smplxd_data['betas'][0, 0] == 0
+    # new with smplxd_data_dict
+    smplxd_data['betas'][0, 0] = 1
+    smplxd_data_dict = dict(smplxd_data)
+    smplxd_data = SMPLXDData.from_dict(smplxd_data_dict)
+    assert smplxd_data['betas'][0, 0] == 1
 
 
 def test_set_gender():

--- a/tests/data_structure/body_model/test_smplxd_data.py
+++ b/tests/data_structure/body_model/test_smplxd_data.py
@@ -29,6 +29,7 @@ def test_new():
         fullpose=np.zeros(shape=(2, 55, 3)),
         transl=np.zeros(shape=(2, 3)),
         betas=np.zeros(shape=(2, 10)),
+        mask=np.ones(shape=(2, )),
         displacement=np.zeros(shape=(2, 10475)),
         logger='root')
     assert smplxd_data['betas'][0, 0] == 0

--- a/xrmocap/core/visualization/render/mpr_renderer.py
+++ b/xrmocap/core/visualization/render/mpr_renderer.py
@@ -1,0 +1,134 @@
+# yapf: disable
+import cv2
+import numpy as np
+import torch
+from typing import Union
+from xrprimer.data_structure.camera import (
+    FisheyeCameraParameter, PinholeCameraParameter,
+)
+from xrprimer.utils.log_utils import get_logger, logging
+
+try:
+    import minimal_pytorch_rasterizer as mpr
+    has_mpr = True
+    import_exception = ''
+except (ImportError, ModuleNotFoundError):
+    has_mpr = False
+    import traceback
+    stack_str = ''
+    for line in traceback.format_stack():
+        if 'frozen' not in line:
+            stack_str += line + '\n'
+    import_exception = traceback.format_exc() + '\n'
+    import_exception = stack_str + import_exception
+# yapf: enable
+
+
+class MPRNormRenderer:
+    """Render normal vectors by minimal_pytorch_rasterizer.
+
+    Among every call of function __call__(), faces of the meshes never change.
+    """
+
+    def __init__(self,
+                 faces: Union[torch.Tensor, np.ndarray],
+                 camera_parameter: Union[PinholeCameraParameter,
+                                         FisheyeCameraParameter],
+                 device: Union[torch.device, str] = 'cuda',
+                 logger: Union[None, str, logging.Logger] = None) -> None:
+        """
+        Args:
+            faces (Union[torch.Tensor, np.ndarray]):
+                Faces of the meshes, in shape [n_faces, 3].
+            camera_parameter (Union[
+                    PinholeCameraParameter,
+                    FisheyeCameraParameter]):
+                The view from which we see meshes.
+                FisheyeCameraParameter will
+                be supported in the future.
+            device (Union[torch.device, str], optional):
+                A specified device. Defaults to 'cuda'.
+            logger (Union[None, str, logging.Logger], optional):
+                Logger for logging. If None, root logger will be selected.
+                Defaults to None.
+
+        Raises:
+            ImportError:
+                minimal_pytorch_rasterizer has not been installed.
+            NotImplementedError:
+                Fisheye support has not been implemented.
+        """
+        self.logger = get_logger(logger)
+        if not has_mpr:
+            self.logger.error(import_exception)
+            raise ImportError
+        if isinstance(camera_parameter, FisheyeCameraParameter):
+            self.logger.error('Fisheye support has not been implemented.')
+            raise NotImplementedError
+        else:
+            self.camera_parameter = camera_parameter.clone()
+        if not self.camera_parameter.world2cam:
+            self.camera_parameter.inverse_extrinsic()
+        k33 = np.array(self.camera_parameter.get_intrinsic(3))
+        self.mpr_pinhole2d = mpr.Pinhole2D(
+            fx=k33[0, 0],
+            fy=k33[1, 1],
+            cx=k33[0, 2],
+            cy=k33[1, 2],
+            h=self.camera_parameter.height,
+            w=self.camera_parameter.width)
+        self.device = torch.device(device)
+        self.r_tensor = torch.tensor(
+            self.camera_parameter.get_extrinsic_r(), device=self.device)
+        self.t_tensor = torch.tensor(
+            self.camera_parameter.get_extrinsic_t(),
+            device=self.device).unsqueeze(0)
+        if isinstance(faces, torch.Tensor):
+            self.faces = faces.clone().detach().to(
+                self.device, dtype=torch.int32)
+        else:
+            self.faces = torch.tensor(
+                faces, dtype=torch.int32, device=self.device)
+
+    def __call__(self,
+                 vertices: torch.Tensor,
+                 background: Union[None, np.ndarray] = None) -> np.ndarray:
+        """Render a single frame. Background will be put at the bottom if
+        offered.
+
+        Args:
+            vertices (torch.Tensor):
+                Vertice location for self.faces, in shape [n_vert, 3].
+            background (Union[None, np.ndarray]):
+                Image array for background in shape [h, w, 3].
+                If None, use black.
+                Defaults to None.
+
+        Raises:
+            ValueError: Vertices and faces are not at the same device.
+
+        Returns:
+            np.ndarray:
+                Image array in shape [h, w, 3].
+        """
+        if not vertices.device == self.faces.device:
+            self.logger.error(
+                'Vertices and faces are not at the same device!' +
+                f'vertices: {vertices.device}\nfaces: {self.faces.device}')
+            raise ValueError
+        vertices = vertices.clone().detach()
+        vertices = vertices @ self.r_tensor.transpose(0, 1) + self.t_tensor
+        coords, normals = mpr.estimate_normals(
+            vertices=vertices, faces=self.faces, pinhole=self.mpr_pinhole2d)
+        vis_normals_cpu = mpr.vis_normals(coords, normals)
+        if background is not None:
+            mask = coords[:, :, [2]] <= 0
+            mask = mask.detach().cpu().numpy()
+            ret_img = vis_normals_cpu[:, :, None] +\
+                background * mask
+        else:
+            # convert gray to 3 channel img
+            ret_img = cv2.merge([
+                vis_normals_cpu,
+            ] * 3)
+        return ret_img

--- a/xrmocap/core/visualization/visualize_smpl.py
+++ b/xrmocap/core/visualization/visualize_smpl.py
@@ -38,7 +38,7 @@ def visualize_smpl_data(
         # input args
         smpl_data: Union[SMPLData, SMPLXData, List[Union[SMPLData,
                                                          SMPLXData]]],
-        body_model: Union[SMPL, SMPLX, dict],
+        body_model: Union[SMPL, SMPLX, dict, List[Union[SMPL, SMPLX, dict]]],
         cam_param: Union[FisheyeCameraParameter, PinholeCameraParameter],
         # output args
         output_path: str,
@@ -53,15 +53,88 @@ def visualize_smpl_data(
         disable_tqdm: bool = True,
         logger: Union[None, str, logging.Logger] = None,
         device: Union[torch.device, str] = 'cuda') -> Union[None, np.ndarray]:
+    """Visualize multi-person multi-gender smpl data on specified background.
+
+    Args:
+        smpl_data (Union[
+                SMPLData, SMPLXData,
+                List[Union[SMPLData, SMPLXData]]]):
+            Input smpl data. Could be an instance of SMPLData or SMPLXData,
+            or a list of them. Mind that all instance in the
+            list must be the same type.
+        body_model (Union[SMPL, SMPLX, dict, List[Union[SMPL, SMPLX, dict]]]):
+            Body model by which we calculate meshes from parameters.
+            Could be a SMPL(X) module, or a dict for building the module,
+            or a list of them if multi-gender is needed.
+        cam_param (Union[FisheyeCameraParameter, PinholeCameraParameter]):
+            Camera from which we watch the smpl bodies.
+        output_path (str):
+            Path to the output mp4 video file or image directory.
+        overwrite (bool, optional):
+            Whether to overwrite the file at output_path.
+            Defaults to True.
+        batch_size (int, optional):
+            How many frames will be in RAM at the same
+            time when plotting.
+            Defaults to 1000.
+        return_array (bool, optional):
+            Whether to return the video array. If True,
+            please make sure your RAM is enough for the video.
+            Defaults to False, return None.
+        background_arr (Union[np.ndarray, None], optional):
+            Background image array. Defaults to None.
+        background_dir (Union[np.ndarray, None], optional):
+            Path to the image directory for background.
+            Defaults to None.
+        background_video (Union[np.ndarray, None], optional):
+            Path to the video for background.
+            Defaults to None.
+        disable_tqdm (bool, optional):
+            Whether to disable tqdm progress bar.
+            Defaults to True.
+        logger (Union[None, str, logging.Logger], optional):
+            Logger for logging. If None, root logger will be selected.
+            Defaults to None.
+        device (Union[torch.device, str], optional):
+            A specified device. Defaults to 'cuda'.
+
+    Raises:
+        NotImplementedError:
+            Function images_to_video() in
+            the latest xrprimer release is not correct.
+
+    Returns:
+        Union[np.ndarray, None]:
+            Plotted multi-frame image array or None.
+            If it's an array, its shape shall be
+            [n_frame, height, width, 3].
+    """
     logger = get_logger(logger)
     _check_output_path(
         output_path=output_path, overwrite=overwrite, logger=logger)
+    body_model_dict = dict()
+    default_body_model = None
+    # prepare body_model_dict for multi-gender
     if isinstance(body_model, dict):
         model = build_body_model(body_model).to(device)
+        body_model_dict[model.gender] = model
+        default_body_model = model
+    elif isinstance(body_model, list):
+        body_model_list = body_model
+        for body_model in body_model_list:
+            if isinstance(body_model, dict):
+                model = build_body_model(body_model).to(device)
+                body_model_dict[model.gender] = model
+            else:
+                model = body_model.to(device)
+                body_model_dict[model.gender] = model
+            default_body_model = model
     else:
         model = body_model.to(device)
+        body_model_dict[model.gender] = model
+        default_body_model = model
     # prepare smpl_data_list for multi-person
-    if not issubclass(smpl_data, dict):
+    if not isinstance(smpl_data, dict):
         data_len = smpl_data[0].get_batch_size()
         smpl_data_list = smpl_data
     else:
@@ -69,8 +142,8 @@ def visualize_smpl_data(
         smpl_data_list = [smpl_data]
     n_person = len(smpl_data_list)
     # prepare faces for multi-person
-    sperson_faces = body_model.faces_tensor.clone().detach()
-    sperson_n_verts = body_model.get_num_verts()
+    sperson_faces = default_body_model.faces_tensor.clone().detach()
+    sperson_n_verts = default_body_model.get_num_verts()
     mperson_faces = None
     for person_idx in range(n_person):
         new_faces = sperson_faces + sperson_n_verts * person_idx
@@ -78,7 +151,7 @@ def visualize_smpl_data(
             mperson_faces = new_faces
         else:
             mperson_faces = torch.cat((mperson_faces, new_faces), dim=0)
-    renderer = MPRVerticeNormRenderer(
+    renderer = MPRNormRenderer(
         faces=mperson_faces,
         camera_parameter=cam_param,
         device=device,
@@ -103,9 +176,11 @@ def visualize_smpl_data(
     for person_idx in range(n_person):
         smpl_data = smpl_data_list[person_idx]
         param_dict = smpl_data.to_tensor_dict(device=device)
+        model = body_model_dict[smpl_data['gender']]
         body_model_output = model(**param_dict)
         verts = body_model_output['vertices']  # n_batch, n_verts, 3
         sperson_verts = torch.unsqueeze(verts, dim=1)
+        # sperson_verts.shape: n_batch, n_person, n_verts, 3
         if mperson_verts is None:
             mperson_verts = sperson_verts
         else:
@@ -145,13 +220,10 @@ def visualize_smpl_data(
             sframe_background = background_arr_batch[frame_idx - start_idx]
             for person_idx in range(n_person):
                 mask_value = smpl_data_list[person_idx].get_mask()[frame_idx]
-                verts_start_idx = person_idx * sperson_n_verts
-                verts_end_idx = (person_idx + 1) * sperson_n_verts
-                sframe_mperson_verts[verts_start_idx,
-                                     verts_end_idx] *= mask_value
+                sframe_mperson_verts[person_idx] *= mask_value
             if sframe_mperson_verts.square().sum() > 0:
                 img = renderer(
-                    vertices=sframe_mperson_verts,
+                    vertices=sframe_mperson_verts.reshape(-1, 3),
                     background=sframe_background)
             else:
                 img = sframe_background
@@ -166,8 +238,8 @@ def visualize_smpl_data(
         img_arr = np.asarray(output_img_list)
     if write_video:
         if write_img:
-            logger.error('Function images_to_video is not ' +
-                         'in the latest release of xrprimer.')
+            logger.error('Function images_to_video() in ' +
+                         'the latest xrprimer release is ' + 'not correct.')
             raise NotImplementedError
         else:
             array_to_video(image_array=img_arr, output_path=output_path)
@@ -176,7 +248,11 @@ def visualize_smpl_data(
     return img_arr if return_array else None
 
 
-class MPRVerticeNormRenderer:
+class MPRNormRenderer:
+    """Render normal vectors by minimal_pytorch_rasterizer.
+
+    Among every call of function __call__(), faces of the meshes never change.
+    """
 
     def __init__(self,
                  faces: Union[torch.Tensor, np.ndarray],
@@ -184,6 +260,28 @@ class MPRVerticeNormRenderer:
                                          FisheyeCameraParameter],
                  device: Union[torch.device, str] = 'cuda',
                  logger: Union[None, str, logging.Logger] = None) -> None:
+        """
+        Args:
+            faces (Union[torch.Tensor, np.ndarray]):
+                Faces of the meshes, in shape [n_faces, 3].
+            camera_parameter (Union[
+                    PinholeCameraParameter,
+                    FisheyeCameraParameter]):
+                The view from which we see meshes.
+                FisheyeCameraParameter will
+                be supported in the future.
+            device (Union[torch.device, str], optional):
+                A specified device. Defaults to 'cuda'.
+            logger (Union[None, str, logging.Logger], optional):
+                Logger for logging. If None, root logger will be selected.
+                Defaults to None.
+
+        Raises:
+            ImportError:
+                minimal_pytorch_rasterizer has not been installed.
+            NotImplementedError:
+                Fisheye support has not been implemented.
+        """
         self.logger = get_logger(logger)
         if not has_mpr:
             self.logger.error(import_exception)
@@ -192,13 +290,23 @@ class MPRVerticeNormRenderer:
             self.logger.error('Fisheye support has not been implemented.')
             raise NotImplementedError
         else:
-            self.camera_parameter = camera_parameter
-
+            self.camera_parameter = camera_parameter.clone()
+        if not self.camera_parameter.world2cam:
+            self.camera_parameter.inverse_extrinsic()
+        k33 = np.array(self.camera_parameter.get_intrinsic(3))
         self.mpr_pinhole2d = mpr.Pinhole2D(
-            K=np.array(self.camera_parameter.get_intrinsic(3)),
+            fx=k33[0, 0],
+            fy=k33[1, 1],
+            cx=k33[0, 2],
+            cy=k33[1, 2],
             h=self.camera_parameter.height,
             w=self.camera_parameter.width)
         self.device = torch.device(device)
+        self.r_tensor = torch.tensor(
+            self.camera_parameter.get_extrinsic_r(), device=self.device)
+        self.t_tensor = torch.tensor(
+            self.camera_parameter.get_extrinsic_t(),
+            device=self.device).unsqueeze(0)
         if isinstance(faces, torch.Tensor):
             self.faces = faces.clone().detach().to(
                 self.device, dtype=torch.int32)
@@ -206,17 +314,40 @@ class MPRVerticeNormRenderer:
             self.faces = torch.tensor(
                 faces, dtype=torch.int32, device=self.device)
 
-    def __call__(self, vertices: torch.Tensor,
-                 background: Union[None, np.ndarray]) -> np.ndarray:
+    def __call__(self,
+                 vertices: torch.Tensor,
+                 background: Union[None, np.ndarray] = None) -> np.ndarray:
+        """Render a single frame. Background will be put at the bottom if
+        offered.
+
+        Args:
+            vertices (torch.Tensor):
+                Vertice location for self.faces, in shape [n_vert, 3].
+            background (Union[None, np.ndarray]):
+                Image array for background in shape [h, w, 3].
+                If None, use black.
+                Defaults to None.
+
+        Raises:
+            ValueError: Vertices and faces are not at the same device.
+
+        Returns:
+            np.ndarray:
+                Image array in shape [h, w, 3].
+        """
         if not vertices.device == self.faces.device:
-            self.logger.error()
+            self.logger.error(
+                'Vertices and faces are not at the same device!' +
+                f'vertices: {vertices.device}\nfaces: {self.faces.device}')
             raise ValueError
         vertices = vertices.clone().detach()
+        vertices = vertices @ self.r_tensor.transpose(0, 1) + self.t_tensor
         coords, normals = mpr.estimate_normals(
             vertices=vertices, faces=self.faces, pinhole=self.mpr_pinhole2d)
         vis_normals_cpu = mpr.vis_normals(coords, normals)
         if background is not None:
             mask = coords[:, :, [2]] <= 0
+            mask = mask.detach().cpu().numpy()
             ret_img = vis_normals_cpu[:, :, None] +\
                 background * mask
         else:

--- a/xrmocap/core/visualization/visualize_smpl.py
+++ b/xrmocap/core/visualization/visualize_smpl.py
@@ -106,21 +106,18 @@ def visualize_smpl_data(
     if isinstance(body_model, dict):
         model = build_body_model(body_model).to(device)
         body_model_dict[model.gender] = model
-        default_body_model = model
     elif isinstance(body_model, list):
         body_model_list = body_model
         for body_model in body_model_list:
             if isinstance(body_model, dict):
                 model = build_body_model(body_model).to(device)
-                body_model_dict[model.gender] = model
             else:
                 model = body_model.to(device)
-                body_model_dict[model.gender] = model
-            default_body_model = model
+            body_model_dict[model.gender] = model
     else:
         model = body_model.to(device)
         body_model_dict[model.gender] = model
-        default_body_model = model
+    default_body_model = model
     # prepare smpl_data_list for multi-person
     if not isinstance(smpl_data, dict):
         data_len = smpl_data[0].get_batch_size()

--- a/xrmocap/core/visualization/visualize_smpl.py
+++ b/xrmocap/core/visualization/visualize_smpl.py
@@ -1,0 +1,241 @@
+# yapf: disable
+import cv2
+import numpy as np
+import os
+import shutil
+import torch
+from tqdm import tqdm
+from typing import List, Union
+from xrprimer.data_structure.camera import (
+    FisheyeCameraParameter, PinholeCameraParameter,
+)
+from xrprimer.utils.ffmpeg_utils import array_to_video, video_to_array
+from xrprimer.utils.log_utils import get_logger, logging
+from xrprimer.utils.path_utils import (
+    Existence, check_path_existence, check_path_suffix,
+)
+
+from xrmocap.data_structure.body_model import SMPLData, SMPLXData
+from xrmocap.model.body_model.builder import SMPL, SMPLX, build_body_model
+
+try:
+    import minimal_pytorch_rasterizer as mpr
+    has_mpr = True
+    import_exception = ''
+except (ImportError, ModuleNotFoundError):
+    has_mpr = False
+    import traceback
+    stack_str = ''
+    for line in traceback.format_stack():
+        if 'frozen' not in line:
+            stack_str += line + '\n'
+    import_exception = traceback.format_exc() + '\n'
+    import_exception = stack_str + import_exception
+# yapf: enable
+
+
+def visualize_smpl_data(
+        # input args
+        smpl_data: Union[SMPLData, SMPLXData, List[Union[SMPLData,
+                                                         SMPLXData]]],
+        body_model: Union[SMPL, SMPLX, dict],
+        cam_param: Union[FisheyeCameraParameter, PinholeCameraParameter],
+        # output args
+        output_path: str,
+        overwrite: bool = False,
+        batch_size: int = 1000,
+        return_array: bool = False,
+        # background args
+        background_arr: Union[np.ndarray, None] = None,
+        background_dir: Union[np.ndarray, None] = None,
+        background_video: Union[np.ndarray, None] = None,
+        # verbose args
+        disable_tqdm: bool = True,
+        logger: Union[None, str, logging.Logger] = None,
+        device: Union[torch.device, str] = 'cuda') -> Union[None, np.ndarray]:
+    logger = get_logger(logger)
+    _check_output_path(
+        output_path=output_path, overwrite=overwrite, logger=logger)
+    if isinstance(body_model, dict):
+        model = build_body_model(body_model).to(device)
+    else:
+        model = body_model.to(device)
+    # prepare smpl_data_list for multi-person
+    if not issubclass(smpl_data, dict):
+        data_len = smpl_data[0].get_batch_size()
+        smpl_data_list = smpl_data
+    else:
+        data_len = smpl_data.get_batch_size()
+        smpl_data_list = [smpl_data]
+    n_person = len(smpl_data_list)
+    # prepare faces for multi-person
+    sperson_faces = body_model.faces_tensor.clone().detach()
+    sperson_n_verts = body_model.get_num_verts()
+    mperson_faces = None
+    for person_idx in range(n_person):
+        new_faces = sperson_faces + sperson_n_verts * person_idx
+        if mperson_faces is None:
+            mperson_faces = new_faces
+        else:
+            mperson_faces = torch.cat((mperson_faces, new_faces), dim=0)
+    renderer = MPRVerticeNormRenderer(
+        faces=mperson_faces,
+        camera_parameter=cam_param,
+        device=device,
+        logger=logger)
+    # check whether to write video directly or write images first
+    if check_path_suffix(output_path, '.mp4'):
+        write_video = True
+        if batch_size < data_len:
+            output_dir = f'{output_path}_temp'
+            os.makedirs(output_dir, exist_ok=True)
+            write_img = True
+            remove_output_dir = True
+        else:
+            write_img = False
+            remove_output_dir = False
+    else:
+        write_video = False
+        output_dir = output_path
+        write_img = True
+        remove_output_dir = False
+    mperson_verts = None
+    for person_idx in range(n_person):
+        smpl_data = smpl_data_list[person_idx]
+        param_dict = smpl_data.to_tensor_dict(device=device)
+        body_model_output = model(**param_dict)
+        verts = body_model_output['vertices']  # n_batch, n_verts, 3
+        sperson_verts = torch.unsqueeze(verts, dim=1)
+        if mperson_verts is None:
+            mperson_verts = sperson_verts
+        else:
+            mperson_verts = torch.cat((mperson_verts, sperson_verts), dim=1)
+    file_names_cache = None
+    output_img_list = []
+    for start_idx in tqdm(
+            range(0, data_len, batch_size), disable=disable_tqdm):
+        end_idx = min(start_idx + batch_size, data_len)
+        # prepare background array for this batch
+        if background_arr is not None:
+            background_arr_batch = background_arr[start_idx:end_idx].copy()
+        elif background_dir is not None:
+            file_names_cache = file_names_cache \
+                if file_names_cache is not None \
+                else sorted(os.listdir(background_dir))
+            file_names_batch = file_names_cache[start_idx:end_idx]
+            background_list_batch = []
+            for file_name in file_names_batch:
+                background_list_batch.append(
+                    np.expand_dims(
+                        cv2.imread(os.path.join(background_dir, file_name)),
+                        axis=0))
+            background_arr_batch = np.concatenate(
+                background_list_batch, axis=0)
+        elif background_video is not None:
+            background_arr_batch = video_to_array(
+                background_video, start=start_idx, end=end_idx)
+        else:
+            background_arr_batch = np.zeros(
+                shape=(end_idx - start_idx, cam_param.height, cam_param.width,
+                       3),
+                dtype=np.uint8)
+        batch_results = []
+        for frame_idx in range(start_idx, end_idx):
+            sframe_mperson_verts = mperson_verts[frame_idx]
+            sframe_background = background_arr_batch[frame_idx - start_idx]
+            for person_idx in range(n_person):
+                mask_value = smpl_data_list[person_idx].get_mask()[frame_idx]
+                verts_start_idx = person_idx * sperson_n_verts
+                verts_end_idx = (person_idx + 1) * sperson_n_verts
+                sframe_mperson_verts[verts_start_idx,
+                                     verts_end_idx] *= mask_value
+            if sframe_mperson_verts.square().sum() > 0:
+                img = renderer(
+                    vertices=sframe_mperson_verts,
+                    background=sframe_background)
+            else:
+                img = sframe_background
+            if write_img:
+                cv2.imwrite(
+                    filename=os.path.join(output_dir, f'{frame_idx:06d}.png'),
+                    img=img)
+            batch_results.append(img)
+        if return_array or write_video:
+            output_img_list += batch_results
+    if return_array or write_video:
+        img_arr = np.asarray(output_img_list)
+    if write_video:
+        if write_img:
+            logger.error('Function images_to_video is not ' +
+                         'in the latest release of xrprimer.')
+            raise NotImplementedError
+        else:
+            array_to_video(image_array=img_arr, output_path=output_path)
+        if remove_output_dir:
+            shutil.rmtree(output_dir)
+    return img_arr if return_array else None
+
+
+class MPRVerticeNormRenderer:
+
+    def __init__(self,
+                 faces: Union[torch.Tensor, np.ndarray],
+                 camera_parameter: Union[PinholeCameraParameter,
+                                         FisheyeCameraParameter],
+                 device: Union[torch.device, str] = 'cuda',
+                 logger: Union[None, str, logging.Logger] = None) -> None:
+        self.logger = get_logger(logger)
+        if not has_mpr:
+            self.logger.error(import_exception)
+            raise ImportError
+        if isinstance(camera_parameter, FisheyeCameraParameter):
+            self.logger.error('Fisheye support has not been implemented.')
+            raise NotImplementedError
+        else:
+            self.camera_parameter = camera_parameter
+
+        self.mpr_pinhole2d = mpr.Pinhole2D(
+            K=np.array(self.camera_parameter.get_intrinsic(3)),
+            h=self.camera_parameter.height,
+            w=self.camera_parameter.width)
+        self.device = torch.device(device)
+        if isinstance(faces, torch.Tensor):
+            self.faces = faces.clone().detach().to(
+                self.device, dtype=torch.int32)
+        else:
+            self.faces = torch.tensor(
+                faces, dtype=torch.int32, device=self.device)
+
+    def __call__(self, vertices: torch.Tensor,
+                 background: Union[None, np.ndarray]) -> np.ndarray:
+        if not vertices.device == self.faces.device:
+            self.logger.error()
+            raise ValueError
+        vertices = vertices.clone().detach()
+        coords, normals = mpr.estimate_normals(
+            vertices=vertices, faces=self.faces, pinhole=self.mpr_pinhole2d)
+        vis_normals_cpu = mpr.vis_normals(coords, normals)
+        if background is not None:
+            mask = coords[:, :, [2]] <= 0
+            ret_img = vis_normals_cpu[:, :, None] +\
+                background * mask
+        else:
+            # convert gray to 3 channel img
+            ret_img = cv2.merge([
+                vis_normals_cpu,
+            ] * 3)
+        return ret_img
+
+
+def _check_output_path(output_path: str, overwrite: bool,
+                       logger: logging.Logger) -> None:
+    existence = check_path_existence(output_path)
+    if existence == Existence.MissingParent:
+        logger.error(f'Parent of {output_path} doesn\'t exist.')
+        raise FileNotFoundError
+    elif (existence == Existence.DirectoryExistNotEmpty
+          or existence == Existence.FileExist) and not overwrite:
+        logger.error(f'{output_path} exists and overwrite not enabled.')
+        raise FileExistsError
+    if not check_path_suffix(output_path, '.mp4'):
+        os.makedirs(output_path, exist_ok=True)

--- a/xrmocap/core/visualization/visualize_smpl.py
+++ b/xrmocap/core/visualization/visualize_smpl.py
@@ -17,20 +17,8 @@ from xrprimer.utils.path_utils import (
 
 from xrmocap.data_structure.body_model import SMPLData, SMPLXData
 from xrmocap.model.body_model.builder import SMPL, SMPLX, build_body_model
+from .render.mpr_renderer import MPRNormRenderer
 
-try:
-    import minimal_pytorch_rasterizer as mpr
-    has_mpr = True
-    import_exception = ''
-except (ImportError, ModuleNotFoundError):
-    has_mpr = False
-    import traceback
-    stack_str = ''
-    for line in traceback.format_stack():
-        if 'frozen' not in line:
-            stack_str += line + '\n'
-    import_exception = traceback.format_exc() + '\n'
-    import_exception = stack_str + import_exception
 # yapf: enable
 
 
@@ -246,116 +234,6 @@ def visualize_smpl_data(
         if remove_output_dir:
             shutil.rmtree(output_dir)
     return img_arr if return_array else None
-
-
-class MPRNormRenderer:
-    """Render normal vectors by minimal_pytorch_rasterizer.
-
-    Among every call of function __call__(), faces of the meshes never change.
-    """
-
-    def __init__(self,
-                 faces: Union[torch.Tensor, np.ndarray],
-                 camera_parameter: Union[PinholeCameraParameter,
-                                         FisheyeCameraParameter],
-                 device: Union[torch.device, str] = 'cuda',
-                 logger: Union[None, str, logging.Logger] = None) -> None:
-        """
-        Args:
-            faces (Union[torch.Tensor, np.ndarray]):
-                Faces of the meshes, in shape [n_faces, 3].
-            camera_parameter (Union[
-                    PinholeCameraParameter,
-                    FisheyeCameraParameter]):
-                The view from which we see meshes.
-                FisheyeCameraParameter will
-                be supported in the future.
-            device (Union[torch.device, str], optional):
-                A specified device. Defaults to 'cuda'.
-            logger (Union[None, str, logging.Logger], optional):
-                Logger for logging. If None, root logger will be selected.
-                Defaults to None.
-
-        Raises:
-            ImportError:
-                minimal_pytorch_rasterizer has not been installed.
-            NotImplementedError:
-                Fisheye support has not been implemented.
-        """
-        self.logger = get_logger(logger)
-        if not has_mpr:
-            self.logger.error(import_exception)
-            raise ImportError
-        if isinstance(camera_parameter, FisheyeCameraParameter):
-            self.logger.error('Fisheye support has not been implemented.')
-            raise NotImplementedError
-        else:
-            self.camera_parameter = camera_parameter.clone()
-        if not self.camera_parameter.world2cam:
-            self.camera_parameter.inverse_extrinsic()
-        k33 = np.array(self.camera_parameter.get_intrinsic(3))
-        self.mpr_pinhole2d = mpr.Pinhole2D(
-            fx=k33[0, 0],
-            fy=k33[1, 1],
-            cx=k33[0, 2],
-            cy=k33[1, 2],
-            h=self.camera_parameter.height,
-            w=self.camera_parameter.width)
-        self.device = torch.device(device)
-        self.r_tensor = torch.tensor(
-            self.camera_parameter.get_extrinsic_r(), device=self.device)
-        self.t_tensor = torch.tensor(
-            self.camera_parameter.get_extrinsic_t(),
-            device=self.device).unsqueeze(0)
-        if isinstance(faces, torch.Tensor):
-            self.faces = faces.clone().detach().to(
-                self.device, dtype=torch.int32)
-        else:
-            self.faces = torch.tensor(
-                faces, dtype=torch.int32, device=self.device)
-
-    def __call__(self,
-                 vertices: torch.Tensor,
-                 background: Union[None, np.ndarray] = None) -> np.ndarray:
-        """Render a single frame. Background will be put at the bottom if
-        offered.
-
-        Args:
-            vertices (torch.Tensor):
-                Vertice location for self.faces, in shape [n_vert, 3].
-            background (Union[None, np.ndarray]):
-                Image array for background in shape [h, w, 3].
-                If None, use black.
-                Defaults to None.
-
-        Raises:
-            ValueError: Vertices and faces are not at the same device.
-
-        Returns:
-            np.ndarray:
-                Image array in shape [h, w, 3].
-        """
-        if not vertices.device == self.faces.device:
-            self.logger.error(
-                'Vertices and faces are not at the same device!' +
-                f'vertices: {vertices.device}\nfaces: {self.faces.device}')
-            raise ValueError
-        vertices = vertices.clone().detach()
-        vertices = vertices @ self.r_tensor.transpose(0, 1) + self.t_tensor
-        coords, normals = mpr.estimate_normals(
-            vertices=vertices, faces=self.faces, pinhole=self.mpr_pinhole2d)
-        vis_normals_cpu = mpr.vis_normals(coords, normals)
-        if background is not None:
-            mask = coords[:, :, [2]] <= 0
-            mask = mask.detach().cpu().numpy()
-            ret_img = vis_normals_cpu[:, :, None] +\
-                background * mask
-        else:
-            # convert gray to 3 channel img
-            ret_img = cv2.merge([
-                vis_normals_cpu,
-            ] * 3)
-        return ret_img
 
 
 def _check_output_path(output_path: str, overwrite: bool,

--- a/xrmocap/data_structure/body_model/smpl_data.py
+++ b/xrmocap/data_structure/body_model/smpl_data.py
@@ -29,21 +29,15 @@ class SMPLData(dict):
     }
 
     def __init__(self,
-                 src_dict: dict = None,
                  gender: Union[Literal['female', 'male', 'neutral'],
                                None] = None,
                  fullpose: Union[np.ndarray, torch.Tensor, None] = None,
                  transl: Union[np.ndarray, torch.Tensor, None] = None,
                  betas: Union[np.ndarray, torch.Tensor, None] = None,
                  logger: Union[None, str, logging.Logger] = None) -> None:
-        """Construct a SMPLData instance with pre-set values. If any of gender,
-        fullpose, transl, betas is provided, it will override the item in
-        source_dict.
+        """Construct a SMPLData instance with pre-set values.
 
         Args:
-            src_dict (dict, optional):
-                A dict with items in HumanData fashion.
-                Defaults to None.
             gender (Union[
                     Literal['female', 'male', 'neutral'], None], optional):
                 Gender of the body model.
@@ -64,10 +58,7 @@ class SMPLData(dict):
                 Logger for logging. If None, root logger will be selected.
                 Defaults to None.
         """
-        if src_dict is not None:
-            super().__init__(src_dict)
-        else:
-            super().__init__()
+        super().__init__()
         self.n_body_joints = self.__class__.DEFAULT_BODY_JOINTS_NUM
         self.logger = get_logger(logger)
         if gender is None and 'gender' not in self:
@@ -102,6 +93,31 @@ class SMPLData(dict):
         """
         ret_instance = cls()
         ret_instance.load(npz_path)
+        return ret_instance
+
+    @classmethod
+    def from_dict(cls, smpl_data_dict: Union['SMPLData', dict]) -> 'SMPLData':
+        """Construct a body model data structure from a SMPLData, or a degraded
+        smpl_data in dict type.
+
+        Args:
+            smpl_data_dict (dict):
+                A degraded smpl_data in dict type.
+
+        Returns:
+            SMPLData:
+                A SMPLData instance load from dict.
+        """
+        assert 'gender' in smpl_data_dict
+        assert 'fullpose' in smpl_data_dict
+        assert 'transl' in smpl_data_dict
+        assert 'betas' in smpl_data_dict
+        ret_instance = cls(
+            gender=smpl_data_dict['gender'],
+            fullpose=smpl_data_dict['fullpose'],
+            transl=smpl_data_dict['transl'],
+            betas=smpl_data_dict['betas'],
+        )
         return ret_instance
 
     @classmethod
@@ -375,7 +391,8 @@ class SMPLData(dict):
         np.savez_compressed(npz_path, **self)
 
     def from_param_dict(self, smpl_dict: dict) -> None:
-        """Load SMPL parameters from smpl_dict.
+        """Load SMPL parameters from smpl_dict, which is the output of a body
+        model in most cases.
 
         Args:
             smpl_dict (dict):

--- a/xrmocap/data_structure/body_model/smpl_data.py
+++ b/xrmocap/data_structure/body_model/smpl_data.py
@@ -56,7 +56,7 @@ class SMPLData(dict):
                 Defaults to None,
                 zero-tensor in shape [n_frame, 10] will be created.
             mask (Union[np.ndarray, torch.Tensor, None], optional):
-                A tensor or ndarray for visibility mask,
+                A tensor or ndarray for framewise visibility mask,
                 in shape [n_frame, ].
                 Defaults to None,
                 one-tensor in shape [n_frame, ] will be created.
@@ -232,7 +232,7 @@ class SMPLData(dict):
         super().__setitem__('betas', betas_np)
 
     def set_mask(self, mask: Union[np.ndarray, torch.Tensor]) -> None:
-        """Set mask data.
+        """Set framewise mask data.
 
         Args:
             mask (Union[np.ndarray, torch.Tensor]):

--- a/xrmocap/data_structure/body_model/smpl_data.py
+++ b/xrmocap/data_structure/body_model/smpl_data.py
@@ -118,10 +118,8 @@ class SMPLData(dict):
             SMPLData:
                 A SMPLData instance load from dict.
         """
-        assert 'gender' in smpl_data_dict
-        assert 'fullpose' in smpl_data_dict
-        assert 'transl' in smpl_data_dict
-        assert 'betas' in smpl_data_dict
+        min_keys = {'gender', 'fullpose', 'transl', 'betas'}
+        assert min_keys <= smpl_data_dict.keys()
         ret_instance = cls(
             gender=smpl_data_dict['gender'],
             fullpose=smpl_data_dict['fullpose'],

--- a/xrmocap/data_structure/body_model/smpl_data.py
+++ b/xrmocap/data_structure/body_model/smpl_data.py
@@ -245,9 +245,9 @@ class SMPLData(dict):
             TypeError: Type of mask is not correct.
         """
         if isinstance(mask, np.ndarray):
-            mask_np = mask.reshape(-1)
+            mask_np = mask.reshape(-1).astype(np.uint8)
         elif isinstance(mask, torch.Tensor):
-            mask_np = mask.detach().cpu().numpy().reshape(-1)
+            mask_np = mask.detach().cpu().numpy().reshape(-1).astype(np.uint8)
         else:
             self.logger.error('Type of mask is not correct.\n' +
                               f'Type: {type(mask)}.')
@@ -351,6 +351,14 @@ class SMPLData(dict):
             ndarray: mask in shape [batch_size, ].
         """
         return self.__getitem__('mask').reshape(-1)
+
+    def get_gender(self) -> str:
+        """Get gender.
+
+        Returns:
+            str: gender in ['neutral', 'female', 'male'].
+        """
+        return self.__getitem__('gender')
 
     def to_param_dict(self, repeat_betas: bool = True) -> dict:
         """Split fullpose into global_orient and body_pose, return all the
@@ -481,4 +489,8 @@ class SMPLData(dict):
         with np.load(npz_path, allow_pickle=True) as npz_file:
             tmp_data_dict = dict(npz_file)
             for key, value in tmp_data_dict.items():
+                if isinstance(value, np.ndarray) and\
+                        len(value.shape) == 0:
+                    # value is not an ndarray before dump
+                    value = value.item()
                 self.__setitem__(key, value)

--- a/xrmocap/data_structure/body_model/smplx_data.py
+++ b/xrmocap/data_structure/body_model/smplx_data.py
@@ -101,11 +101,8 @@ class SMPLXData(SMPLData):
                 A SMPLXData instance load from dict.
         """
         smplx_data_dict = smpl_data_dict
-        assert 'gender' in smplx_data_dict
-        assert 'fullpose' in smplx_data_dict
-        assert 'transl' in smplx_data_dict
-        assert 'betas' in smplx_data_dict
-        assert 'expression' in smplx_data_dict
+        min_keys = {'gender', 'fullpose', 'transl', 'betas', 'expression'}
+        assert min_keys <= smplx_data_dict.keys()
         ret_instance = cls(
             gender=smplx_data_dict['gender'],
             fullpose=smplx_data_dict['fullpose'],

--- a/xrmocap/data_structure/body_model/smplx_data.py
+++ b/xrmocap/data_structure/body_model/smplx_data.py
@@ -64,7 +64,7 @@ class SMPLXData(SMPLData):
                 Defaults to None,
                 zero-tensor in shape [frame_num, 10] will be created.
             mask (Union[np.ndarray, torch.Tensor, None], optional):
-                A tensor or ndarray for visibility mask,
+                A tensor or ndarray for framewise visibility mask,
                 in shape [n_frame, ].
                 Defaults to None,
                 one-tensor in shape [n_frame, ] will be created.

--- a/xrmocap/data_structure/body_model/smplx_data.py
+++ b/xrmocap/data_structure/body_model/smplx_data.py
@@ -37,6 +37,7 @@ class SMPLXData(SMPLData):
                  transl: Union[np.ndarray, torch.Tensor, None] = None,
                  betas: Union[np.ndarray, torch.Tensor, None] = None,
                  expression: Union[np.ndarray, torch.Tensor, None] = None,
+                 mask: Union[np.ndarray, torch.Tensor, None] = None,
                  logger: Union[None, str, logging.Logger] = None) -> None:
         """Construct a SMPLXData instance with pre-set values.
 
@@ -62,6 +63,11 @@ class SMPLXData(SMPLData):
                 in shape [frame_num, expression_dim].
                 Defaults to None,
                 zero-tensor in shape [frame_num, 10] will be created.
+            mask (Union[np.ndarray, torch.Tensor, None], optional):
+                A tensor or ndarray for visibility mask,
+                in shape [n_frame, ].
+                Defaults to None,
+                one-tensor in shape [n_frame, ] will be created.
             logger (Union[None, str, logging.Logger], optional):
                 Logger for logging. If None, root logger will be selected.
                 Defaults to None.
@@ -72,6 +78,7 @@ class SMPLXData(SMPLData):
             transl=transl,
             fullpose=fullpose,
             betas=betas,
+            mask=mask,
             logger=logger)
         if expression is None and 'expression' not in self:
             expression = np.zeros(shape=(self.get_batch_size(), 10))

--- a/xrmocap/data_structure/body_model/smplx_data.py
+++ b/xrmocap/data_structure/body_model/smplx_data.py
@@ -31,7 +31,6 @@ class SMPLXData(SMPLData):
     }
 
     def __init__(self,
-                 src_dict: dict = None,
                  gender: Union[Literal['female', 'male', 'neutral'],
                                None] = None,
                  fullpose: Union[np.ndarray, torch.Tensor, None] = None,
@@ -39,14 +38,9 @@ class SMPLXData(SMPLData):
                  betas: Union[np.ndarray, torch.Tensor, None] = None,
                  expression: Union[np.ndarray, torch.Tensor, None] = None,
                  logger: Union[None, str, logging.Logger] = None) -> None:
-        """Construct a SMPLXData instance with pre-set values. If any of
-        gender, fullpose, transl, betas is provided, it will override the item
-        in source_dict.
+        """Construct a SMPLXData instance with pre-set values.
 
         Args:
-            src_dict (dict, optional):
-                A dict with items in HumanData fashion.
-                Defaults to None.
             gender (Union[
                     Literal['female', 'male', 'neutral'], None], optional):
                 Gender of the body model.
@@ -74,7 +68,6 @@ class SMPLXData(SMPLData):
         """
         SMPLData.__init__(
             self,
-            src_dict=src_dict,
             gender=gender,
             transl=transl,
             fullpose=fullpose,
@@ -85,6 +78,34 @@ class SMPLXData(SMPLData):
         if expression is not None:
             self.set_expression(expression)
         self.body_joints_num = self.__class__.DEFAULT_BODY_JOINTS_NUM
+
+    @classmethod
+    def from_dict(cls, smpl_data_dict: Union['SMPLXData',
+                                             dict]) -> 'SMPLXData':
+        """Construct a body model data structure from a SMPLXData, or a
+        degraded smplx_data in dict type.
+
+        Args:
+            smplx_data_dict (dict):
+                A degraded smplx_data in dict type.
+
+        Returns:
+            SMPLXData:
+                A SMPLXData instance load from dict.
+        """
+        smplx_data_dict = smpl_data_dict
+        assert 'gender' in smplx_data_dict
+        assert 'fullpose' in smplx_data_dict
+        assert 'transl' in smplx_data_dict
+        assert 'betas' in smplx_data_dict
+        assert 'expression' in smplx_data_dict
+        ret_instance = cls(
+            gender=smplx_data_dict['gender'],
+            fullpose=smplx_data_dict['fullpose'],
+            transl=smplx_data_dict['transl'],
+            betas=smplx_data_dict['betas'],
+            expression=smplx_data_dict['expression'])
+        return ret_instance
 
     @classmethod
     def get_fullpose_dim(cls) -> int:
@@ -160,7 +181,8 @@ class SMPLXData(SMPLData):
             SMPLData.__setitem__(self, __k, __v)
 
     def from_param_dict(self, smplx_dict: dict) -> None:
-        """Load SMPLX parameters from smplx_dict.
+        """Load SMPLX parameters from smplx_dict, which is the output of a body
+        model in most cases.
 
         Args:
             smplx_dict (dict):

--- a/xrmocap/data_structure/body_model/smplxd_data.py
+++ b/xrmocap/data_structure/body_model/smplxd_data.py
@@ -26,6 +26,7 @@ class SMPLXDData(SMPLXData):
                  betas: Union[np.ndarray, torch.Tensor, None] = None,
                  expression: Union[np.ndarray, torch.Tensor, None] = None,
                  displacement: Union[np.ndarray, torch.Tensor, None] = None,
+                 mask: Union[np.ndarray, torch.Tensor, None] = None,
                  logger: Union[None, str, logging.Logger] = None) -> None:
         """Construct a SMPLXData instance with pre-set values.
 
@@ -56,6 +57,11 @@ class SMPLXDData(SMPLXData):
                 in shape [frame_num, NUM_VERTS].
                 Defaults to None,
                 zero-tensor in shape [frame_num, NUM_VERTS] will be created.
+            mask (Union[np.ndarray, torch.Tensor, None], optional):
+                A tensor or ndarray for visibility mask,
+                in shape [n_frame, ].
+                Defaults to None,
+                one-tensor in shape [n_frame, ] will be created.
             logger (Union[None, str, logging.Logger], optional):
                 Logger for logging. If None, root logger will be selected.
                 Defaults to None.
@@ -67,6 +73,7 @@ class SMPLXDData(SMPLXData):
             fullpose=fullpose,
             betas=betas,
             expression=expression,
+            mask=mask,
             logger=logger)
         if displacement is None and 'displacement' not in self:
             displacement = np.zeros(

--- a/xrmocap/data_structure/body_model/smplxd_data.py
+++ b/xrmocap/data_structure/body_model/smplxd_data.py
@@ -58,7 +58,7 @@ class SMPLXDData(SMPLXData):
                 Defaults to None,
                 zero-tensor in shape [frame_num, NUM_VERTS] will be created.
             mask (Union[np.ndarray, torch.Tensor, None], optional):
-                A tensor or ndarray for visibility mask,
+                A tensor or ndarray for framewise visibility mask,
                 in shape [n_frame, ].
                 Defaults to None,
                 one-tensor in shape [n_frame, ] will be created.

--- a/xrmocap/data_structure/body_model/smplxd_data.py
+++ b/xrmocap/data_structure/body_model/smplxd_data.py
@@ -19,7 +19,6 @@ class SMPLXDData(SMPLXData):
     NUM_VERTS = 10475
 
     def __init__(self,
-                 src_dict: dict = None,
                  gender: Union[Literal['female', 'male', 'neutral'],
                                None] = None,
                  fullpose: Union[np.ndarray, torch.Tensor, None] = None,
@@ -28,14 +27,9 @@ class SMPLXDData(SMPLXData):
                  expression: Union[np.ndarray, torch.Tensor, None] = None,
                  displacement: Union[np.ndarray, torch.Tensor, None] = None,
                  logger: Union[None, str, logging.Logger] = None) -> None:
-        """Construct a SMPLXData instance with pre-set values. If any of
-        gender, fullpose, transl, betas is provided, it will override the item
-        in source_dict.
+        """Construct a SMPLXData instance with pre-set values.
 
         Args:
-            src_dict (dict, optional):
-                A dict with items in HumanData fashion.
-                Defaults to None.
             gender (Union[
                     Literal['female', 'male', 'neutral'], None], optional):
                 Gender of the body model.
@@ -68,7 +62,6 @@ class SMPLXDData(SMPLXData):
         """
         SMPLXData.__init__(
             self,
-            src_dict=src_dict,
             gender=gender,
             transl=transl,
             fullpose=fullpose,
@@ -80,6 +73,36 @@ class SMPLXDData(SMPLXData):
                 shape=(self.get_batch_size(), self.__class__.NUM_VERTS))
         if displacement is not None:
             self.set_displacement(displacement)
+
+    @classmethod
+    def from_dict(cls, smpl_data_dict: Union['SMPLXDData',
+                                             dict]) -> 'SMPLXDData':
+        """Construct a body model data structure from a SMPLXDData, or a
+        degraded smplxd_data in dict type.
+
+        Args:
+            smplxd_data_dict (dict):
+                A degraded smplxd_data in dict type.
+
+        Returns:
+            SMPLXData:
+                A SMPLXDData instance load from dict.
+        """
+        smplxd_data_dict = smpl_data_dict
+        assert 'gender' in smplxd_data_dict
+        assert 'fullpose' in smplxd_data_dict
+        assert 'transl' in smplxd_data_dict
+        assert 'betas' in smplxd_data_dict
+        assert 'expression' in smplxd_data_dict
+        assert 'displacement' in smplxd_data_dict
+        ret_instance = cls(
+            gender=smplxd_data_dict['gender'],
+            fullpose=smplxd_data_dict['fullpose'],
+            transl=smplxd_data_dict['transl'],
+            betas=smplxd_data_dict['betas'],
+            expression=smplxd_data_dict['expression'],
+            displacement=smplxd_data_dict['displacement'])
+        return ret_instance
 
     def set_displacement(
             self, displacement: Union[np.ndarray, torch.Tensor]) -> None:
@@ -128,7 +151,8 @@ class SMPLXDData(SMPLXData):
             SMPLXData.__setitem__(self, __k, __v)
 
     def from_param_dict(self, smplxd_dict: dict) -> None:
-        """Load SMPLX+D parameters from smplxd_dict.
+        """Load SMPLX+D parameters from smplxd_dict, which is the output of a
+        body model in most cases.
 
         Args:
             smplx_dict (dict):

--- a/xrmocap/data_structure/body_model/smplxd_data.py
+++ b/xrmocap/data_structure/body_model/smplxd_data.py
@@ -96,12 +96,11 @@ class SMPLXDData(SMPLXData):
                 A SMPLXDData instance load from dict.
         """
         smplxd_data_dict = smpl_data_dict
-        assert 'gender' in smplxd_data_dict
-        assert 'fullpose' in smplxd_data_dict
-        assert 'transl' in smplxd_data_dict
-        assert 'betas' in smplxd_data_dict
-        assert 'expression' in smplxd_data_dict
-        assert 'displacement' in smplxd_data_dict
+        min_keys = {
+            'gender', 'fullpose', 'transl', 'betas', 'expression',
+            'displacement'
+        }
+        assert min_keys <= smplxd_data_dict.keys()
         ret_instance = cls(
             gender=smplxd_data_dict['gender'],
             fullpose=smplxd_data_dict['fullpose'],


### PR DESCRIPTION
1. Fix lint error caused by isort.
2. Clarify difference between `param_dict` and `dict(smpl_data)` by removing `src_dict` and add `from_dict()`.
3. Add mask in smpl_data. The person whose mask is zero will not be plotted.
5. Fix wrong gender type when calling `SMPLData.fromfile()`
4. Add smpl visualization and unit test, based on `minimal_pytorch_rasterizer`. Multi-person and multi-gender are supported.
5. Update dockerfile and docker image, as well as install.md.
6. Some designed features have not been enabled. They will not be OK until their requirements in XRPrimer is updated.