### PR TITLE
[Fix] Fix SMPLify error and incomplete docs

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -24,8 +24,24 @@ We list some common troubles faced by many users and their corresponding solutio
 
 - 'BrokenPipeError: ../../lib/python3.8/site-packages/xrprimer/utils/ffmpeg_utils.py:189: BrokenPipeError'
 
-  You've installed a wrong version of ffmpeg. Try to install it by the following command, and do not 	specify any channel:
+  You've installed a wrong version of ffmpeg. Try to install it by the following command, and do not specify any channel:
 
   ```bash
   conda install ffmpeg
+  ```
+
+- 'ImportError:numpy.core.multiarray failed to import'
+
+  Numpy of some versions is not compatible with mmpose, so is scipy. Install a tested version will help:
+
+  ```bash
+  pip install numpy==1.23.5 scipy==1.10.0
+  ```
+
+- 'RuntimeError: nms_impl: implementation for device cuda:0 not found.'
+
+  You have a newer mmcv-full and an older mmdet. Install an older mmcv-full may help. Remember to modify torch and cuda version according to your environment:
+
+  ```bash
+  pip install mmcv-full==1.6.1 -f https://download.openmmlab.com/mmcv/dist/cu113/torch1.12.0/index.html
   ```

--- a/docs/en/tools/process_smc.md
+++ b/docs/en/tools/process_smc.md
@@ -25,6 +25,13 @@ Also, you can find our prepared config files at `config/estimation/mview_sperson
 
 By default, disable_log_file is False and a log file named `{smc_file_name}_{time_str}.txt` will be written. Add `--disable_log_file` makes it True and the tool will only print log to console.
 
+### Argument: frame_file
+
+By default, frame_file is `'none'` frames in SMC will not be saved in file system, the tool fetches frames of one view
+each time, loads them into memory and runs human perception. If the SMC is too long or your have a poor RAM,
+`frame_file='temp'` will help you save the frames as image files in output_dir, and remove the temporary files at the
+end of this tool. If you need the frames for further usage, set `frame_file='keep'` and the files won't be removed.
+
 ### Argument: visualize
 
 By default, visualize is False. Add `--visualize` makes it True and the tool will visualize keypoints3d with an orbit camera, overlay projected keypoints3d on some views, and overlay SMPL meshes on one view.

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,8 +1,8 @@
 filterpy
-numpy
+numpy==1.23.5
 opencv-python-headless
 pre-commit
 prettytable
-scipy
+scipy==1.10.0
 smplx
 tqdm

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,10 +2,10 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 filterpy
 h5py
 mediapipe
-mmdet @ git+https://github.com/open-mmlab/mmdetection.git@2.27.0
+mmdet @ git+https://github.com/open-mmlab/mmdetection.git@v2.27.0
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
-mmpose @ git+https://github.com/open-mmlab/mmpose.git@0.29.0
-mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@0.14.0
+mmpose @ git+https://github.com/open-mmlab/mmpose.git@v0.29.0
+mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@v0.14.0
 numpy
 pre-commit
 prettytable

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,11 +2,10 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 filterpy
 h5py
 mediapipe
-minimal_pytorch_rasterizer @ git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git
-mmdet @ git+https://github.com/open-mmlab/mmdetection.git
+mmdet @ git+https://github.com/open-mmlab/mmdetection.git@2.27.0
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
-mmpose @ git+https://github.com/open-mmlab/mmpose.git
-mmtrack @ git+https://github.com/open-mmlab/mmtracking.git
+mmpose @ git+https://github.com/open-mmlab/mmpose.git@0.29.0
+mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@0.14.0
 numpy
 pre-commit
 prettytable

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,11 +2,10 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 coverage
 filterpy
 mediapipe
-minimal_pytorch_rasterizer @ git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git
-mmdet @ git+https://github.com/open-mmlab/mmdetection.git
+mmdet @ git+https://github.com/open-mmlab/mmdetection.git@2.27.0
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
-mmpose @ git+https://github.com/open-mmlab/mmpose.git
-mmtrack @ git+https://github.com/open-mmlab/mmtracking.git
+mmpose @ git+https://github.com/open-mmlab/mmpose.git@0.29.0
+mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@0.14.0
 numpy
 pre-commit
 prettytable

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,10 +2,10 @@ aniposelib @ git+https://github.com/liruilong940607/aniposelib.git
 coverage
 filterpy
 mediapipe
-mmdet @ git+https://github.com/open-mmlab/mmdetection.git@2.27.0
+mmdet @ git+https://github.com/open-mmlab/mmdetection.git@v2.27.0
 mmhuman3d @ git+https://github.com/open-mmlab/mmhuman3d.git
-mmpose @ git+https://github.com/open-mmlab/mmpose.git@0.29.0
-mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@0.14.0
+mmpose @ git+https://github.com/open-mmlab/mmpose.git@v0.29.0
+mmtrack @ git+https://github.com/open-mmlab/mmtracking.git@v0.14.0
 numpy
 pre-commit
 prettytable

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,6 @@ multi_line_output = 5
 include_trailing_comma = true
 known_standard_library = pkg_resources,setuptools
 known_first_party = xrmocap
-known_third_party =PIL,cv2,filterpy,h5py,matplotlib,mediapipe,mmcv,mmhuman3d,numpy,prettytable,pytest,pytorch3d,scipy,smplx,sphinx_rtd_theme,torch,torchvision,tqdm,xrprimer
+known_third_party =PIL,cv2,filterpy,h5py,matplotlib,mmcv,mmhuman3d,numpy,prettytable,pytest,pytorch3d,scipy,smplx,sphinx_rtd_theme,torch,torchvision,tqdm,xrprimer
 no_lines_before = STDLIB,LOCALFOLDER
 default_section = THIRDPARTY

--- a/tools/process_smc.py
+++ b/tools/process_smc.py
@@ -79,7 +79,11 @@ def main(args):
         keypoints2d_path = os.path.join(
             args.output_dir,
             f'{smc_name}_keypoints2d_' + f'view{index:02d}.npz')
-        keypoints2d.dump(keypoints2d_path)
+        if keypoints2d is not None:
+            keypoints2d.dump(keypoints2d_path)
+        else:
+            logger.warning(
+                f'No keypoints2d has been detected in view{index:02d}.')
     keypoints3d_path = os.path.join(args.output_dir,
                                     f'{smc_name}_keypoints3d.npz')
     keypoints3d.dump(keypoints3d_path)

--- a/tools/process_smc.py
+++ b/tools/process_smc.py
@@ -53,28 +53,49 @@ def main(args):
     # load camera parameter and images
     cam_param_list = get_all_color_kinect_parameter_from_smc(
         smc_reader=smc_reader, align_floor=True, logger=logger)
-    mview_img_list = []
-    frame_temp_dir = os.path.join(args.output_dir, f'{smc_name}_temp_frames')
-    prepare_output_path(
-        output_path=frame_temp_dir,
-        tag='Temp dir for smc frames',
-        path_type='dir',
-        overwrite=True,
-        logger=logger)
+    # use frames in file system
+    if args.frame_file != 'none':
+        frame_temp_dir = os.path.join(args.output_dir,
+                                      f'{smc_name}_temp_frames')
+        prepare_output_path(
+            output_path=frame_temp_dir,
+            tag='Temp dir for smc frames',
+            path_type='dir',
+            overwrite=True,
+            logger=logger)
+        mview_img_list = []
+    # use frames in smc
+    else:
+        keypoints2d_list = []
     for kinect_index in range(smc_reader.num_kinects):
-        view_temp_dir = os.path.join(frame_temp_dir,
-                                     f'view_{kinect_index:02d}')
-        temp_dir_exist = check_path_existence(view_temp_dir, 'dir')
-        if not (args.keep_frames
-                and temp_dir_exist == Existence.DirectoryExistNotEmpty):
+        if args.frame_file == 'none':
             sv_img_array = smc_reader.get_kinect_color(kinect_id=kinect_index)
             sv_img_array = bgr2rgb(sv_img_array)
-            array_to_images(sv_img_array, view_temp_dir, logger=logger)
-        sview_img_list = sorted(
-            glob.glob(os.path.join(view_temp_dir, '*.png')))
-        mview_img_list.append(sview_img_list)
-    keypoints2d_list, keypoints3d, smpl_data = mview_sp_smpl_estimator.run(
-        cam_param=cam_param_list, img_paths=mview_img_list)
+            sv_img_array = np.expand_dims(sv_img_array, 0)
+            sv_keypoints2d_list = mview_sp_smpl_estimator.estimate_keypoints2d(
+                img_arr=sv_img_array)
+            keypoints2d_list += sv_keypoints2d_list
+        else:
+            view_temp_dir = os.path.join(frame_temp_dir,
+                                         f'view_{kinect_index:02d}')
+            temp_dir_exist = check_path_existence(view_temp_dir, 'dir')
+            if not (args.frame_file == 'keep'
+                    and temp_dir_exist == Existence.DirectoryExistNotEmpty):
+                sv_img_array = smc_reader.get_kinect_color(
+                    kinect_id=kinect_index)
+                sv_img_array = bgr2rgb(sv_img_array)
+                array_to_images(sv_img_array, view_temp_dir, logger=logger)
+            sview_img_list = sorted(
+                glob.glob(os.path.join(view_temp_dir, '*.png')))
+            mview_img_list.append(sview_img_list)
+    if args.frame_file != 'none':
+        keypoints2d_list, keypoints3d, smpl_data = mview_sp_smpl_estimator.run(
+            cam_param=cam_param_list, img_paths=mview_img_list)
+    else:
+        keypoints3d = mview_sp_smpl_estimator.estimate_keypoints3d(
+            cam_param=cam_param_list, keypoints2d_list=keypoints2d_list)
+        smpl_data = mview_sp_smpl_estimator.estimate_smpl(
+            keypoints3d=keypoints3d, init_smpl_data=None)
     for index, keypoints2d in enumerate(keypoints2d_list):
         keypoints2d_path = os.path.join(
             args.output_dir,
@@ -94,7 +115,7 @@ def main(args):
     smpl_path = os.path.join(args.output_dir,
                              f'{smc_name}_{smpl_type}_data.npz')
     smpl_data.dump(smpl_path)
-    if not args.keep_frames:
+    if args.frame_file == 'temp':
         shutil.rmtree(frame_temp_dir)
     # write results to the output smc
 
@@ -198,11 +219,13 @@ def setup_parser():
         help='If checked, visualize result.',
         default=False)
     parser.add_argument(
-        '--keep_frames',
-        action='store_true',
-        help='If checked, frames extracted from SMC' +
-        ' will be kept in file system.',
-        default=False)
+        '--frame_file',
+        type=str,
+        help='Whether to extract frames' + ' and save them in file system.' +
+        ' `none` for not saving,' + ' `temp` for save temporarily,' +
+        ' `keep` for save without deleting.',
+        choices=['none', 'temp', 'keep'],
+        default='none')
     # log args
     parser.add_argument(
         '--disable_log_file',

--- a/xrmocap/core/estimation/mview_sperson_smpl_estimator.py
+++ b/xrmocap/core/estimation/mview_sperson_smpl_estimator.py
@@ -235,60 +235,31 @@ class MultiViewSinglePersonSMPLEstimator(BaseEstimator):
             keypoints3d=keypoints3d, init_smpl_data=init_smpl_data)
         return keypoints2d_list, keypoints3d, smpl_data
 
-    def estimate_keypoints2d(
-        self,
-        img_arr: Union[None, np.ndarray] = None,
-        img_paths: Union[None, List[List[str]]] = None,
-    ) -> List[Keypoints]:
+    def estimate_keypoints2d(self, img_arr: np.ndarray) -> List[Keypoints]:
         """Estimate keypoints2d in a top-down way.
 
         Args:
-            img_arr (Union[None, np.ndarray], optional):
+            img_arr (np.ndarray):
                 A multi-view image array, in shape
-                [n_view, n_frame, h, w, c]. Defaults to None.
-            img_paths (Union[None, List[List[str]]], optional):
-                A nested list of image paths, in shape
-                [n_view, n_frame]. Defaults to None.
+                [n_view, n_frame, h, w, c].
 
         Returns:
             List[Keypoints]:
                 A list of keypoints2d instances.
         """
         self.logger.info('Estimating keypoints2d.')
-        input_list = [img_arr, img_paths]
-        input_count = 0
-        for input_instance in input_list:
-            if input_instance is not None:
-                input_count += 1
-        if input_count > 1:
-            self.logger.error('Redundant input!\n' +
-                              'Please offer only one between' +
-                              ' img_arr, img_paths.')
-            raise ValueError
         ret_list = []
         for view_index in range(img_arr.shape[0]):
-            if img_arr is not None:
-                view_img_arr = img_arr[view_index]
-                bbox_list = self.bbox_detector.infer_array(
-                    image_array=view_img_arr,
-                    disable_tqdm=(not self.verbose),
-                    multi_person=False)
-                kps2d_list, _, _ = self.kps2d_estimator.infer_array(
-                    image_array=view_img_arr,
-                    bbox_list=bbox_list,
-                    disable_tqdm=(not self.verbose),
-                )
-            else:
-                bbox_list = self.bbox_detector.infer_frames(
-                    frame_path_list=img_paths,
-                    disable_tqdm=(not self.verbose),
-                    multi_person=True,
-                    load_batch_size=self.load_batch_size)
-                kps2d_list, _, _ = self.kps2d_estimator.infer_frames(
-                    frame_path_list=img_paths,
-                    bbox_list=bbox_list,
-                    disable_tqdm=(not self.verbose),
-                    load_batch_size=self.load_batch_size)
+            view_img_arr = img_arr[view_index]
+            bbox_list = self.bbox_detector.infer_array(
+                image_array=view_img_arr,
+                disable_tqdm=(not self.verbose),
+                multi_person=False)
+            kps2d_list, _, _ = self.kps2d_estimator.infer_array(
+                image_array=view_img_arr,
+                bbox_list=bbox_list,
+                disable_tqdm=(not self.verbose),
+            )
             if len(kps2d_list) == 1 and \
                     len(kps2d_list[0]) == 1 and \
                     kps2d_list[0][0] is None:

--- a/xrmocap/human_perception/keypoints_estimation/mediapipe_estimator.py
+++ b/xrmocap/human_perception/keypoints_estimation/mediapipe_estimator.py
@@ -1,6 +1,5 @@
 import cv2
 import logging
-import mediapipe as mp
 import numpy as np
 from tqdm import tqdm
 from typing import List, Tuple, Union
@@ -9,6 +8,20 @@ from xrprimer.utils.log_utils import get_logger
 
 from xrmocap.data_structure.keypoints import Keypoints
 from xrmocap.transform.convention.keypoints_convention import get_keypoint_num
+
+try:
+    import mediapipe as mp
+    has_mediapipe = True
+    import_exception = ''
+except (ImportError, ModuleNotFoundError):
+    has_mediapipe = False
+    import traceback
+    stack_str = ''
+    for line in traceback.format_stack():
+        if 'frozen' not in line:
+            stack_str += line + '\n'
+    import_exception = traceback.format_exc() + '\n'
+    import_exception = stack_str + import_exception
 
 
 class MediapipeEstimator():
@@ -32,6 +45,10 @@ class MediapipeEstimator():
                 Defaults to None.
         """
         # build the pose model
+        if not has_mediapipe:
+            self.logger.error(import_exception)
+            raise ModuleNotFoundError(
+                'Please install mediapipe by `pip install mediapipe`.')
         mp_pose = mp.solutions.pose
         self.pose_model = mp_pose.Pose(**mediapipe_kwargs)
         self.bbox_thr = bbox_thr

--- a/xrmocap/model/loss/prior_loss.py
+++ b/xrmocap/model/loss/prior_loss.py
@@ -287,6 +287,10 @@ class SmoothJointLoss(torch.nn.Module):
             torch.Tensor: The calculated loss
         """
         assert reduction_override in (None, 'none', 'mean', 'sum')
+        # No smooth when there's only one frame
+        if body_pose.shape[0] <= 1:
+            return torch.zeros_like(body_pose[0, 0])
+
         reduction = reduction_override \
             if reduction_override is not None \
             else self.reduction


### PR DESCRIPTION
1. Add more frequent questions.
2. Remove minimal_pytorch_rasterizer from pip requirements. It won't be installed by default.
3. Make installation doc more detailed.
4. Add version in requirements.
5. Make import sentences for mediapipe optional.
6. Allow process_smc tool not writing images to file system. It runs faster in large RAM machine.
7. Fix error when smooth joint loss gets one-frame input.