### PR TITLE
[Fix] Fix failed lint workflow

### DIFF
--- a/configs/modules/core/evaluation/mview_mperson_eval_shelf_unittest.py
+++ b/configs/modules/core/evaluation/mview_mperson_eval_shelf_unittest.py
@@ -61,7 +61,7 @@ dataset = dict(
     img_pipeline=[
         dict(type='LoadImagePIL'),
         dict(type='ToTensor'),
-        dict(type='BGR2RGB'),
+        dict(type='RGB2BGR'),
     ],
     meta_path=__meta_path__,
     test_mode=True,

--- a/configs/modules/data/dataset/mvpose_shelf_testset.py
+++ b/configs/modules/data/dataset/mvpose_shelf_testset.py
@@ -4,7 +4,7 @@ img_pipeline = [
     dict(type='LoadImagePIL'),
     dict(type='Resize', size=224),
     dict(type='ToTensor'),
-    dict(type='BGR2RGB'),
+    dict(type='RGB2BGR'),
 ]
 meta_path = 'xrmocap_meta_testset'
 test_mode = True

--- a/configs/modules/data/dataset/shelf_unittest.py
+++ b/configs/modules/data/dataset/shelf_unittest.py
@@ -4,7 +4,7 @@ img_pipeline = [
     dict(type='LoadImagePIL'),
     dict(type='Resize', size=224),
     dict(type='ToTensor'),
-    dict(type='BGR2RGB'),
+    dict(type='RGB2BGR'),
 ]
 meta_path = 'tests/data/data/test_dataset/Shelf_unittest/' +\
     'xrmocap_meta_perception2d'

--- a/configs/mvpose/campus_config/eval_keypoints3d.py
+++ b/configs/mvpose/campus_config/eval_keypoints3d.py
@@ -59,7 +59,7 @@ dataset = dict(
     img_pipeline=[
         dict(type='LoadImagePIL'),
         dict(type='ToTensor'),
-        dict(type='BGR2RGB'),
+        dict(type='RGB2BGR'),
     ],
     meta_path=__meta_path__,
     test_mode=True,

--- a/configs/mvpose/shelf_config/eval_keypoints3d.py
+++ b/configs/mvpose/shelf_config/eval_keypoints3d.py
@@ -59,7 +59,7 @@ dataset = dict(
     img_pipeline=[
         dict(type='LoadImagePIL'),
         dict(type='ToTensor'),
-        dict(type='BGR2RGB'),
+        dict(type='RGB2BGR'),
     ],
     meta_path=__meta_path__,
     test_mode=True,

--- a/configs/mvpose_tracking/panoptic_config/eval_keypoints3d.py
+++ b/configs/mvpose_tracking/panoptic_config/eval_keypoints3d.py
@@ -61,7 +61,7 @@ dataset = dict(
     img_pipeline=[
         dict(type='LoadImagePIL'),
         dict(type='ToTensor'),
-        dict(type='BGR2RGB'),
+        dict(type='RGB2BGR'),
     ],
     meta_path=__meta_path__,
     test_mode=True,

--- a/tests/data_structure/body_model/test_smpl_data.py
+++ b/tests/data_structure/body_model/test_smpl_data.py
@@ -4,7 +4,7 @@ import pytest
 import shutil
 import torch
 
-from xrmocap.data_structure.body_model import SMPLData
+from xrmocap.data_structure.body_model import SMPLData, auto_load_smpl_data
 
 output_dir = 'tests/data/output/data_structure/' +\
     'body_model/test_smpl_data'
@@ -166,3 +166,13 @@ def test_file_io():
     with pytest.raises(FileExistsError):
         smpl_data.dump(npz_path, overwrite=False)
     smpl_data.dump(npz_path, overwrite=True)
+    # test auto load
+    instance, class_name = auto_load_smpl_data(npz_path)
+    assert isinstance(instance, SMPLData)
+    assert class_name == 'SMPLData'
+    # test wrong type auto load
+    npz_path = os.path.join(output_dir, 'dumped_some_data.npz')
+    dict_to_dump = dict(a='a', b='b')
+    np.savez_compressed(npz_path, **dict_to_dump)
+    with pytest.raises(TypeError):
+        instance, class_name = auto_load_smpl_data(npz_path)

--- a/tests/data_structure/body_model/test_smpl_data.py
+++ b/tests/data_structure/body_model/test_smpl_data.py
@@ -170,6 +170,8 @@ def test_file_io():
     instance, class_name = auto_load_smpl_data(npz_path)
     assert isinstance(instance, SMPLData)
     assert class_name == 'SMPLData'
+    assert instance.get_fullpose().shape[1] == SMPLData.get_fullpose_dim()
+    assert 'expression' not in instance
     # test wrong type auto load
     npz_path = os.path.join(output_dir, 'dumped_some_data.npz')
     dict_to_dump = dict(a='a', b='b')

--- a/tests/data_structure/body_model/test_smplx_data.py
+++ b/tests/data_structure/body_model/test_smplx_data.py
@@ -4,7 +4,7 @@ import pytest
 import shutil
 import torch
 
-from xrmocap.data_structure.body_model import SMPLXData
+from xrmocap.data_structure.body_model import SMPLXData, auto_load_smpl_data
 
 output_dir = 'tests/data/output/data_structure/' +\
     'body_model/test_smplx_data'
@@ -179,3 +179,7 @@ def test_file_io():
     with pytest.raises(FileExistsError):
         smplx_data.dump(npz_path, overwrite=False)
     smplx_data.dump(npz_path, overwrite=True)
+    # test auto load
+    instance, class_name = auto_load_smpl_data(npz_path)
+    assert isinstance(instance, SMPLXData)
+    assert class_name == 'SMPLXData'

--- a/tests/data_structure/body_model/test_smplx_data.py
+++ b/tests/data_structure/body_model/test_smplx_data.py
@@ -183,3 +183,5 @@ def test_file_io():
     instance, class_name = auto_load_smpl_data(npz_path)
     assert isinstance(instance, SMPLXData)
     assert class_name == 'SMPLXData'
+    assert instance.get_fullpose().shape[1] == SMPLXData.get_fullpose_dim()
+    assert 'expression' in instance

--- a/tests/data_structure/body_model/test_smplxd_data.py
+++ b/tests/data_structure/body_model/test_smplxd_data.py
@@ -4,7 +4,7 @@ import pytest
 import shutil
 import torch
 
-from xrmocap.data_structure.body_model import SMPLXDData
+from xrmocap.data_structure.body_model import SMPLXDData, auto_load_smpl_data
 
 output_dir = 'tests/data/output/data_structure/' +\
     'body_model/test_smplxd_data'
@@ -181,3 +181,7 @@ def test_file_io():
     with pytest.raises(FileExistsError):
         smplxd_data.dump(npz_path, overwrite=False)
     smplxd_data.dump(npz_path, overwrite=True)
+    # test auto load
+    instance, class_name = auto_load_smpl_data(npz_path)
+    assert isinstance(instance, SMPLXDData)
+    assert class_name == 'SMPLXDData'

--- a/tests/data_structure/body_model/test_smplxd_data.py
+++ b/tests/data_structure/body_model/test_smplxd_data.py
@@ -185,3 +185,6 @@ def test_file_io():
     instance, class_name = auto_load_smpl_data(npz_path)
     assert isinstance(instance, SMPLXDData)
     assert class_name == 'SMPLXDData'
+    assert instance.get_fullpose().shape[1] == SMPLXDData.get_fullpose_dim()
+    assert 'expression' in instance
+    assert 'displacement' in instance

--- a/tests/transform/image/test_color.py
+++ b/tests/transform/image/test_color.py
@@ -52,3 +52,12 @@ def test_bgr2rgb():
     bgr_image = bgr2rgb(rgb_image, color_dim=-1)
     assert bgr_image[0, 0, 0, 0] == 2
     assert bgr_image[0, 0, 0, 2] == 0
+    # test in-place
+    rgb_image = np.zeros(shape=(3, 1920, 1080))
+    rgb_image[2, ...] = 2
+    rgb2bgr(rgb_image, color_dim=0, inplace=True)
+    assert rgb_image[0, 0, 0] == 2
+    rgb_image = torch.zeros(size=(3, 1920, 1080))
+    rgb_image[2, ...] = 2
+    rgb2bgr(rgb_image, color_dim=0, inplace=True)
+    assert rgb_image[0, 0, 0] == 2

--- a/tests/transform/image/test_color.py
+++ b/tests/transform/image/test_color.py
@@ -10,24 +10,24 @@ def test_bgr2rgb():
     rgb_image = np.zeros(shape=(3, 1920, 1080))
     rgb_image[2, ...] = 2
     assert rgb_image[2, 0, 0] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=0)
-    assert bgr_image[0, 0, 0] == 2
-    assert bgr_image[2, 0, 0] == 0
     bgr_image = rgb2bgr(rgb_image, color_dim=0)
     assert bgr_image[0, 0, 0] == 2
     assert bgr_image[2, 0, 0] == 0
+    rgb_image = bgr2rgb(bgr_image, color_dim=0)
+    assert rgb_image[2, 0, 0] == 2
+    assert rgb_image[0, 0, 0] == 0
     # pytorch batch like
     rgb_image = np.zeros(shape=(2, 3, 1920, 1080))
     rgb_image[:, 2, ...] = 2
     assert rgb_image[0, 2, 0, 0] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=1)
+    bgr_image = rgb2bgr(rgb_image, color_dim=1)
     assert bgr_image[0, 0, 0, 0] == 2
     assert bgr_image[0, 2, 0, 0] == 0
     # opencv video like
     rgb_image = np.zeros(shape=(2, 1920, 1080, 3))
     rgb_image[..., 2] = 2
     assert rgb_image[0, 0, 0, 2] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=-1)
+    bgr_image = rgb2bgr(rgb_image, color_dim=-1)
     assert bgr_image[0, 0, 0, 0] == 2
     assert bgr_image[0, 0, 0, 2] == 0
     # test torch
@@ -35,21 +35,21 @@ def test_bgr2rgb():
     rgb_image = torch.zeros(size=(3, 1920, 1080))
     rgb_image[2, ...] = 2
     assert rgb_image[2, 0, 0] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=0)
+    bgr_image = rgb2bgr(rgb_image, color_dim=0)
     assert bgr_image[0, 0, 0] == 2
     assert bgr_image[2, 0, 0] == 0
     # pytorch batch like
     rgb_image = torch.zeros(size=(2, 3, 1920, 1080))
     rgb_image[:, 2, ...] = 2
     assert rgb_image[0, 2, 0, 0] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=1)
+    bgr_image = rgb2bgr(rgb_image, color_dim=1)
     assert bgr_image[0, 0, 0, 0] == 2
     assert bgr_image[0, 2, 0, 0] == 0
     # opencv video like
     rgb_image = torch.zeros(size=(2, 1920, 1080, 3))
     rgb_image[..., 2] = 2
     assert rgb_image[0, 0, 0, 2] == 2
-    bgr_image = bgr2rgb(rgb_image, color_dim=-1)
+    bgr_image = rgb2bgr(rgb_image, color_dim=-1)
     assert bgr_image[0, 0, 0, 0] == 2
     assert bgr_image[0, 0, 0, 2] == 0
     # test in-place

--- a/tests/transform/image/test_color.py
+++ b/tests/transform/image/test_color.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 
-from xrmocap.transform.image.color import bgr2rgb
+from xrmocap.transform.image.color import bgr2rgb, rgb2bgr
 
 
 def test_bgr2rgb():
@@ -11,6 +11,9 @@ def test_bgr2rgb():
     rgb_image[2, ...] = 2
     assert rgb_image[2, 0, 0] == 2
     bgr_image = bgr2rgb(rgb_image, color_dim=0)
+    assert bgr_image[0, 0, 0] == 2
+    assert bgr_image[2, 0, 0] == 0
+    bgr_image = rgb2bgr(rgb_image, color_dim=0)
     assert bgr_image[0, 0, 0] == 2
     assert bgr_image[2, 0, 0] == 0
     # pytorch batch like

--- a/tools/process_smc.py
+++ b/tools/process_smc.py
@@ -20,7 +20,7 @@ from xrmocap.core.estimation.builder import build_estimator
 from xrmocap.data_structure.body_model import SMPLXData
 from xrmocap.data_structure.smc_reader import SMCReader
 from xrmocap.io.camera import get_all_color_kinect_parameter_from_smc
-from xrmocap.transform.image.color import bgr2rgb
+from xrmocap.transform.image.color import rgb2bgr
 
 # yapf: enable
 
@@ -70,7 +70,7 @@ def main(args):
     for kinect_index in range(smc_reader.num_kinects):
         if args.frame_file == 'none':
             sv_img_array = smc_reader.get_kinect_color(kinect_id=kinect_index)
-            sv_img_array = bgr2rgb(sv_img_array)
+            sv_img_array = rgb2bgr(sv_img_array)
             sv_img_array = np.expand_dims(sv_img_array, 0)
             sv_keypoints2d_list = mview_sp_smpl_estimator.estimate_keypoints2d(
                 img_arr=sv_img_array)
@@ -83,7 +83,7 @@ def main(args):
                     and temp_dir_exist == Existence.DirectoryExistNotEmpty):
                 sv_img_array = smc_reader.get_kinect_color(
                     kinect_id=kinect_index)
-                sv_img_array = bgr2rgb(sv_img_array)
+                sv_img_array = rgb2bgr(sv_img_array)
                 array_to_images(sv_img_array, view_temp_dir, logger=logger)
             sview_img_list = sorted(
                 glob.glob(os.path.join(view_temp_dir, '*.png')))
@@ -141,7 +141,7 @@ def main(args):
             for view_idx in range(0, len(mview_kps2d), 3):
                 sview_kps2d = mview_kps2d[view_idx]
                 image_array = smc_reader.get_kinect_color(kinect_id=view_idx)
-                image_array = bgr2rgb(image_array)
+                image_array = rgb2bgr(image_array)
                 visualize_kp2d(
                     kp2d=sview_kps2d,
                     image_array=image_array,
@@ -178,7 +178,7 @@ def main(args):
                 cam_param.inverse_extrinsic()
             image_array = smc_reader.get_kinect_color(
                 kinect_id=selected_kinect)
-            image_array = bgr2rgb(image_array)
+            image_array = rgb2bgr(image_array)
             motion_len = smpl_data['fullpose'].shape[0]
             visualize_smpl_calibration(
                 poses=smpl_data['fullpose'].reshape(motion_len, -1),

--- a/xrmocap/data_structure/body_model/__init__.py
+++ b/xrmocap/data_structure/body_model/__init__.py
@@ -1,5 +1,63 @@
+import numpy as np
+from typing import Tuple, Union
+from xrprimer.utils.log_utils import get_logger, logging
+
 from .smpl_data import SMPLData
 from .smplx_data import SMPLXData
 from .smplxd_data import SMPLXDData
 
 __all__ = ['SMPLData', 'SMPLXData', 'SMPLXDData']
+
+_SMPL_DATA_CLASS_DICT = dict(
+    SMPLData=SMPLData, SMPLXData=SMPLXData, SMPLXDData=SMPLXDData)
+
+
+def auto_load_smpl_data(
+    npz_path: str,
+    logger: Union[None, str, logging.Logger] = None
+) -> Tuple[Union[SMPLData, SMPLXData, SMPLXDData], str]:
+    """Check which smpl data type the npz file is, and use the correct class to
+    load it. Useful when you forget file type.
+
+    Args:
+        npz_path (str):
+            Path to a dumped npz file.
+        logger (Union[None, str, logging.Logger], optional):
+            Logger for logging. If None, root logger will be selected.
+            Defaults to None.
+
+    Returns:
+        Union[SMPLData, SMPLXData, SMPLXDData]:
+            Loaded SMPL/SMPLX/SMPLXD Data instance.
+        str:
+            Type(class name) of this npz file.
+    """
+    logger = get_logger(logger)
+    unpacked_dict = dict()
+    with np.load(npz_path, allow_pickle=True) as npz_file:
+        tmp_data_dict = dict(npz_file)
+        for key, value in tmp_data_dict.items():
+            if isinstance(value, np.ndarray) and\
+                    len(value.shape) == 0:
+                # value is not an ndarray before dump
+                value = value.item()
+            unpacked_dict.__setitem__(key, value)
+    if 'fullpose' in unpacked_dict:
+        fullpose_dim = unpacked_dict['fullpose'].shape[1]
+    else:
+        fullpose_dim = 0
+    if 'displacement' in unpacked_dict and \
+            fullpose_dim == SMPLXDData.get_fullpose_dim():
+        type_str = 'SMPLXDData'
+    elif 'expression' in unpacked_dict and \
+            fullpose_dim == SMPLXData.get_fullpose_dim():
+        type_str = 'SMPLXData'
+    elif fullpose_dim == SMPLData.get_fullpose_dim():
+        type_str = 'SMPLData'
+    else:
+        logger.error(f'File at {npz_path} is not dumped' +
+                     f' by any of {list(_SMPL_DATA_CLASS_DICT.keys())}.')
+        raise TypeError
+    smpl_data_class = _SMPL_DATA_CLASS_DICT[type_str]
+    smpl_data_instance = smpl_data_class.from_dict(unpacked_dict)
+    return smpl_data_instance, type_str

--- a/xrmocap/model/body_model/smplx.py
+++ b/xrmocap/model/body_model/smplx.py
@@ -102,8 +102,11 @@ class SMPLX(_SMPLX):
         """
 
         kwargs['get_skin'] = True
-        smplx_output = super(SMPLX, self).forward(*args, return_verts=return_verts, 
-                                                  return_full_pose=return_full_pose, **kwargs)
+        smplx_output = super(SMPLX, self).forward(
+            *args,
+            return_verts=return_verts,
+            return_full_pose=return_full_pose,
+            **kwargs)
 
         if not hasattr(self, 'joints_regressor'):
             joints = smplx_output.joints

--- a/xrmocap/transform/image/builder.py
+++ b/xrmocap/transform/image/builder.py
@@ -2,7 +2,7 @@
 from mmcv.utils import Registry
 from torchvision.transforms import Normalize, Resize, ToTensor
 
-from .color import BGR2RGB
+from .color import BGR2RGB, RGB2BGR
 from .convert import CV2ToPIL
 from .load import LoadImageCV2, LoadImagePIL
 from .shape import WarpAffine
@@ -11,6 +11,7 @@ from .shape import WarpAffine
 
 IMAGE_TRANSFORM = Registry('image_transform')
 IMAGE_TRANSFORM.register_module(name='BGR2RGB', module=BGR2RGB)
+IMAGE_TRANSFORM.register_module(name='RGB2BGR', module=RGB2BGR)
 IMAGE_TRANSFORM.register_module(name='LoadImageCV2', module=LoadImageCV2)
 IMAGE_TRANSFORM.register_module(name='LoadImagePIL', module=LoadImagePIL)
 IMAGE_TRANSFORM.register_module(name='CV2ToPIL', module=CV2ToPIL)

--- a/xrmocap/transform/image/color.py
+++ b/xrmocap/transform/image/color.py
@@ -40,6 +40,23 @@ class BGR2RGB(BaseImageTransform):
         return bgr2rgb(input, self.color_dim)
 
 
+class RGB2BGR(BGR2RGB):
+
+    def __init__(self,
+                 color_dim: int = -1,
+                 logger: Union[None, str, logging.Logger] = None) -> None:
+        """Convert image array of any shape between BGR and RGB.
+
+        Args:
+            color_dim (int, optional):
+                Which dim is the color channel. Defaults to -1.
+            logger (Union[None, str, logging.Logger], optional):
+                Logger for logging. If None, root logger will be selected.
+                Defaults to None.
+        """
+        BGR2RGB.__init__(self, color_dim=color_dim, logger=logger)
+
+
 def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
             color_dim: int = -1) -> Union[np.ndarray, torch.Tensor]:
     """Convert image array of any shape between BGR and RGB.
@@ -71,3 +88,22 @@ def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
     input_array[tuple(b_slice_list)] = input_array[tuple(r_slice_list)]
     input_array[tuple(r_slice_list)] = b_backup
     return input_array
+
+
+def rgb2bgr(input_array: Union[np.ndarray, torch.Tensor],
+            color_dim: int = -1) -> Union[np.ndarray, torch.Tensor]:
+    """Convert image array of any shape between BGR and RGB.
+
+    Args:
+        input_array (Union[np.ndarray, torch.Tensor]):
+            An array of images. The shape could be:
+            [h, w, n_ch], [n_frame, h, w, n_ch],
+            [n_view, n_frame, h, w, n_ch], etc.
+        color_dim (int, optional):
+            Which dim is the color channel. Defaults to -1.
+
+    Returns:
+        Union[np.ndarray, torch.Tensor]:
+            Same type as the input.
+    """
+    return bgr2rgb(input_array=input_array, color_dim=color_dim)

--- a/xrmocap/transform/image/color.py
+++ b/xrmocap/transform/image/color.py
@@ -58,7 +58,8 @@ class RGB2BGR(BGR2RGB):
 
 
 def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
-            color_dim: int = -1) -> Union[np.ndarray, torch.Tensor]:
+            color_dim: int = -1,
+            inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
     """Convert image array of any shape between BGR and RGB.
 
     Args:
@@ -68,6 +69,9 @@ def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
             [n_view, n_frame, h, w, n_ch], etc.
         color_dim (int, optional):
             Which dim is the color channel. Defaults to -1.
+        inplace (bool, optional):
+            Whether it is an in-place operation.
+            Defaults to False.
 
     Returns:
         Union[np.ndarray, torch.Tensor]:
@@ -83,15 +87,24 @@ def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
     b_slice_list[color_dim] = slice(2, 3, 1)
     if isinstance(input_array, torch.Tensor):
         b_backup = input_array[tuple(b_slice_list)].clone()
+        if not inplace:
+            ret_array = input_array.clone()
+        else:
+            ret_array = input_array
     else:
         b_backup = input_array[tuple(b_slice_list)].copy()
-    input_array[tuple(b_slice_list)] = input_array[tuple(r_slice_list)]
-    input_array[tuple(r_slice_list)] = b_backup
-    return input_array
+        if not inplace:
+            ret_array = input_array.copy()
+        else:
+            ret_array = input_array
+    ret_array[tuple(b_slice_list)] = input_array[tuple(r_slice_list)]
+    ret_array[tuple(r_slice_list)] = b_backup
+    return ret_array
 
 
 def rgb2bgr(input_array: Union[np.ndarray, torch.Tensor],
-            color_dim: int = -1) -> Union[np.ndarray, torch.Tensor]:
+            color_dim: int = -1,
+            inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
     """Convert image array of any shape between BGR and RGB.
 
     Args:
@@ -101,9 +114,13 @@ def rgb2bgr(input_array: Union[np.ndarray, torch.Tensor],
             [n_view, n_frame, h, w, n_ch], etc.
         color_dim (int, optional):
             Which dim is the color channel. Defaults to -1.
+        inplace (bool, optional):
+            Whether it is an in-place operation.
+            Defaults to False.
 
     Returns:
         Union[np.ndarray, torch.Tensor]:
             Same type as the input.
     """
-    return bgr2rgb(input_array=input_array, color_dim=color_dim)
+    return bgr2rgb(
+        input_array=input_array, color_dim=color_dim, inplace=inplace)

--- a/xrmocap/transform/image/color.py
+++ b/xrmocap/transform/image/color.py
@@ -37,7 +37,7 @@ class BGR2RGB(BaseImageTransform):
         Returns:
             Union[np.ndarray, torch.Tensor]
         """
-        return bgr2rgb(input, self.color_dim)
+        return switch_channel(input, self.color_dim, False)
 
 
 class RGB2BGR(BGR2RGB):
@@ -57,18 +57,20 @@ class RGB2BGR(BGR2RGB):
         BGR2RGB.__init__(self, color_dim=color_dim, logger=logger)
 
 
-def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
-            color_dim: int = -1,
-            inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
-    """Convert image array of any shape between BGR and RGB.
+def switch_channel(input_array: Union[np.ndarray, torch.Tensor],
+                   color_dim: int = -1,
+                   inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
+    """Switch the 1st channel and 3rd channel at color_dim.
 
     Args:
         input_array (Union[np.ndarray, torch.Tensor]):
             An array of images. The shape could be:
             [h, w, n_ch], [n_frame, h, w, n_ch],
             [n_view, n_frame, h, w, n_ch], etc.
+            And n_ch shall be 3.
         color_dim (int, optional):
-            Which dim is the color channel. Defaults to -1.
+            Which dim is the color channel.
+            Defaults to -1, the last dim.
         inplace (bool, optional):
             Whether it is an in-place operation.
             Defaults to False.
@@ -86,26 +88,28 @@ def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
     r_slice_list[color_dim] = slice(0, 1, 1)
     b_slice_list[color_dim] = slice(2, 3, 1)
     if isinstance(input_array, torch.Tensor):
-        b_backup = input_array[tuple(b_slice_list)].clone()
+        b_idxs = tuple(b_slice_list)
+        r_idxs = tuple(r_slice_list)
+        b_backup = input_array[b_idxs].clone()
         if not inplace:
             ret_array = input_array.clone()
         else:
             ret_array = input_array
     else:
-        b_backup = input_array[tuple(b_slice_list)].copy()
+        b_backup = input_array[b_idxs].copy()
         if not inplace:
             ret_array = input_array.copy()
         else:
             ret_array = input_array
-    ret_array[tuple(b_slice_list)] = input_array[tuple(r_slice_list)]
-    ret_array[tuple(r_slice_list)] = b_backup
+    ret_array[b_idxs] = input_array[r_idxs]
+    ret_array[r_idxs] = b_backup
     return ret_array
 
 
 def rgb2bgr(input_array: Union[np.ndarray, torch.Tensor],
             color_dim: int = -1,
             inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
-    """Convert image array of any shape between BGR and RGB.
+    """Convert RGB image array of any shape to BGR.
 
     Args:
         input_array (Union[np.ndarray, torch.Tensor]):
@@ -122,5 +126,29 @@ def rgb2bgr(input_array: Union[np.ndarray, torch.Tensor],
         Union[np.ndarray, torch.Tensor]:
             Same type as the input.
     """
-    return bgr2rgb(
+    return switch_channel(
+        input_array=input_array, color_dim=color_dim, inplace=inplace)
+
+
+def bgr2rgb(input_array: Union[np.ndarray, torch.Tensor],
+            color_dim: int = -1,
+            inplace: bool = False) -> Union[np.ndarray, torch.Tensor]:
+    """Convert BGR image array of any shape to RGB.
+
+    Args:
+        input_array (Union[np.ndarray, torch.Tensor]):
+            An array of images. The shape could be:
+            [h, w, n_ch], [n_frame, h, w, n_ch],
+            [n_view, n_frame, h, w, n_ch], etc.
+        color_dim (int, optional):
+            Which dim is the color channel. Defaults to -1.
+        inplace (bool, optional):
+            Whether it is an in-place operation.
+            Defaults to False.
+
+    Returns:
+        Union[np.ndarray, torch.Tensor]:
+            Same type as the input.
+    """
+    return switch_channel(
         input_array=input_array, color_dim=color_dim, inplace=inplace)

--- a/xrmocap/transform/image/color.py
+++ b/xrmocap/transform/image/color.py
@@ -87,9 +87,9 @@ def switch_channel(input_array: Union[np.ndarray, torch.Tensor],
     ] * len(input_array.shape)
     r_slice_list[color_dim] = slice(0, 1, 1)
     b_slice_list[color_dim] = slice(2, 3, 1)
+    b_idxs = tuple(b_slice_list)
+    r_idxs = tuple(r_slice_list)
     if isinstance(input_array, torch.Tensor):
-        b_idxs = tuple(b_slice_list)
-        r_idxs = tuple(r_slice_list)
         b_backup = input_array[b_idxs].clone()
         if not inplace:
             ret_array = input_array.clone()


### PR DESCRIPTION
1. Fix failed lint workflow, caused by an old PR.
2. Add class RGB2BGR and function rgb2bgr, literally fix some color conversion.
3. Add function auto_load_smpl_data, choose a correct class when you forget of which type the npz file is.