### PR TITLE
[Fix] Fix import error from utils files

### DIFF
--- a/xrmocap/utils/__init__.py
+++ b/xrmocap/utils/__init__.py
@@ -1,8 +1,0 @@
-# yapf: disable
-from .camera_utils import (
-    project_point_radial, project_pose, unfold_camera_param,
-)
-
-# yapf: enable
-
-__all__ = ['project_point_radial', 'project_pose', 'unfold_camera_param']


### PR DESCRIPTION
Fix import error when users call `from xrmocap.utils.xxx_utils import xxx`.