### PR TITLE
Update dependencies for docker image

### DIFF
--- a/dockerfiles/runtime_ubt22/Dockerfile
+++ b/dockerfiles/runtime_ubt22/Dockerfile
@@ -1,0 +1,88 @@
+# Please build this dockerfile with nvidia-container-runtime
+FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+
+# Install apt packages
+RUN apt-get update && \
+    apt-get install -y \
+        wget git vim \
+        make \
+        libblas-dev liblapack-dev libatlas-base-dev\
+    && \
+    apt-get autoclean
+
+# Install miniconda
+RUN wget -q \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    && bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda \
+    && rm -f Miniconda3-latest-Linux-x86_64.sh
+
+# Update in bashrc
+RUN echo "source /opt/miniconda/etc/profile.d/conda.sh" >> /root/.bashrc && \
+    echo "conda deactivate" >> /root/.bashrc
+
+# Prepare python env
+ARG PY_VER
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda create -n openxrlab python=$PY_VER -y && \
+    conda activate openxrlab && \
+    conda install ffmpeg -y && \
+    conda clean -y --all
+
+# Prepare pytorch env
+ARG CUDA_VER
+ARG TORCH_VER
+ARG TORCHV_VER
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    conda install pytorch==$TORCH_VER torchvision==$TORCHV_VER pytorch-cuda=$CUDA_VER cudatoolkit=$CUDA_VER -c pytorch -c nvidia -y && \
+    conda clean -y --all
+
+# Prepare pytorch3d env
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    conda install -c fvcore -c iopath -c conda-forge fvcore iopath && \
+    conda install -c bottler nvidiacub && \
+    conda install pytorch3d -c pytorch3d && \
+    conda clean -y --all
+
+# Prepare pip env
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip install pre-commit interrogate coverage pytest && \
+    pip install xrprimer && \
+    pip cache purge
+
+# Install build requirements
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip install -r https://raw.githubusercontent.com/openxrlab/xrmocap/main/requirements/build.txt && \
+    pip cache purge
+
+# Install test requirements
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip install -r https://raw.githubusercontent.com/openxrlab/xrmocap/main/requirements/test.txt && \
+    pip cache purge
+
+# Install mmhuman3d
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    cd /opt && \
+    git clone https://github.com/open-mmlab/mmhuman3d.git && \
+    cd mmhuman3d && pip install -e . && \
+    pip cache purge
+
+# Re-install numpy+scipy for mm-repos and smplx
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip uninstall scipy numpy -y && \
+    pip install numpy==1.23.5 scipy==1.10.0 && \
+    pip cache purge
+
+# Re-install opencv for headless system
+# For cudagl base image, please remove both and re-install opencv-python
+RUN . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip uninstall opencv-python opencv-python-headless -y && \
+    pip install opencv-python-headless && \
+    pip cache purge

--- a/dockerfiles/runtime_ubt22/build_runtime_docker.sh
+++ b/dockerfiles/runtime_ubt22/build_runtime_docker.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+CUDA_VER=11.8
+PY_VER=3.10
+MMCV_VER=1.7.0
+TORCH_VER=2.0.1
+TORCHV_VER=0.15.2
+CUDA_VER_DIGIT=${CUDA_VER//./}
+PY_VER_DIGIT=${PY_VER//./}
+MMCV_VER_DIGIT=${MMCV_VER//./}
+TORCH_VER_DIGIT=${TORCH_VER//./}
+FINAL_TAG="openxrlab/xrmocap_runtime:ubuntu2204_x64_cuda${CUDA_VER_DIGIT}_py${PY_VER_DIGIT}_torch${TORCH_VER_DIGIT}_mmcv${MMCV_VER_DIGIT}"
+echo "tag to build: $FINAL_TAG"
+BUILD_ARGS="--build-arg CUDA_VER=${CUDA_VER} --build-arg PY_VER=${PY_VER} --build-arg MMCV_VER=${MMCV_VER} --build-arg TORCH_VER=${TORCH_VER} --build-arg TORCHV_VER=${TORCHV_VER}"
+# build according to Dockerfile
+TAG=${FINAL_TAG}_not_compatible
+docker build -t $TAG -f dockerfiles/runtime_ubt18/Dockerfile $BUILD_ARGS --progress=plain .
+# Install mpr and mmcv-full with GPU
+CONTAINER_ID=$(docker run -it --gpus all -d $TAG)
+docker exec -ti $CONTAINER_ID sh -c "
+    . /opt/miniconda/etc/profile.d/conda.sh && \
+    conda activate openxrlab && \
+    pip install -U openmim && \
+    mim install mmcv-full==${MMCV_VER} && \    
+    pip install git+https://github.com/rmbashirov/minimal_pytorch_rasterizer.git && \
+    pip cache purge
+"
+docker commit $CONTAINER_ID $FINAL_TAG
+docker rm -f $CONTAINER_ID
+docker rmi $TAG
+echo "Successfully tagged $FINAL_TAG"

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -223,7 +223,7 @@ We provide a Dockerfile to build a runtime image. Ensure that you are using [doc
 Or pull a built image from docker hub.
 
 ```shell
-docker pull openxrlab/xrmocap_runtime:ubuntu1804_x64_cuda116_py38_torch1121_mmcv161
+docker pull openxrlab/xrmocap_runtime:ubuntu2204_x64_cuda118_py310_torch201_mmcv170
 ```
 
 Run it with:

--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-TAG="openxrlab/xrmocap_runtime:ubuntu1804_x64_cuda116_py38_torch1121_mmcv161"
+TAG="openxrlab/xrmocap_runtime:ubuntu2204_x64_cuda118_py310_torch201_mmcv170"
 # modify data mount below
 VOLUMES="-v $PWD:/workspace/xrmocap -v /data:/workspace/xrmocap/data"
 WORKDIR="-w /workspace/xrmocap"


### PR DESCRIPTION
This PR updates the dependencies in the docker image as follows:

```
UBUNTU 18.04 -> 22.04
CUDA_VER 11.6 -> 11.8
PY_VER 3.8 -> 3.10
MMCV_VER 1.6.1 -> 1.7.0
TORCH_VER 1.12.1 -> 2.0.1
TORCHV_VER 0.13.1 -> 0.15.2
```
I also updated the docs to point to the new image that can be built with the new docker file. There are newer versions all of these libs but they won't work because:
- The last `cudatoolkit` in conda in 11.8, limiting the CUDA version to that 
- The last `pytorch3d` version in conda is for python 3.10 and torch 2.0.1
- The MMCV version was limited also to 1.7.0 but I didn't make a note of what breaks when updated further.