### PR TITLE
Fix visualize_keypoints3d_projected method

### DIFF
--- a/tools/mview_mperson_topdown_estimator.py
+++ b/tools/mview_mperson_topdown_estimator.py
@@ -15,7 +15,7 @@ from xrprimer.data_structure.camera import FisheyeCameraParameter
 from xrprimer.utils.log_utils import setup_logger
 
 from xrmocap.core.estimation.builder import build_estimator
-from xrmocap.core.visualization import visualize_project_keypoints3d
+from xrmocap.visualization import visualize_keypoints3d_projected
 
 # yapf: enable
 
@@ -102,12 +102,12 @@ def main(args):
                 image_list.append(image_np)
             image_array = np.array(image_list)
 
-            visualize_project_keypoints3d(
+            visualize_keypoints3d_projected(
                 keypoints=pred_keypoints3d,
-                cam_param=fisheye_param,
+                camera=fisheye_param,
                 output_path=os.path.join(args.output_dir, 'kps3d',
                                          f'project_view_{view_name}.mp4'),
-                img_arr=image_array.copy(),
+                background_img_list=mview_img_list[idx],
                 overwrite=True)
 
             visualize_smpl_calibration(

--- a/xrmocap/visualization/visualize_keypoints2d.py
+++ b/xrmocap/visualization/visualize_keypoints2d.py
@@ -2,6 +2,7 @@
 import cv2
 import numpy as np
 import os
+from mmhuman3d.utils.ffmpeg_utils import prepare_output_path
 from tqdm import tqdm
 from typing import List, Union
 from xrprimer.data_structure.keypoints import Keypoints
@@ -189,6 +190,14 @@ def visualize_keypoints2d(
         line_palette = None
         mframe_line_data = None
         mframe_line_mask = None
+
+    prepare_output_path(
+        output_path=output_path,
+        allowed_suffix=['.mp4', 'gif', ''],
+        tag='output video',
+        path_type='auto',
+        overwrite=overwrite)
+
     ret_value = plot_video(
         output_path=output_path,
         overwrite=overwrite,


### PR DESCRIPTION
The `visualize_project_keypoints3d` does not exist anymore. This PR updates the `mview_mperson_topdown_estimator.py` estimator method to use the new function, `visualize_keypoints3d_projected`.

I also had to add the folder creation function for the output videos, as the first time that it runs, the folder doesn't exist and the script crashes there.